### PR TITLE
webreq v0.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ coverage
 *.lcov
 test/mockdata/output
 lib/mappings
+*.bak
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.0
+
+* Added support for providing certificate options with HTTPS requests. See further documentation: [https](https://nodejs.org/api/https.html#https_https_request_options_callback) and [tls](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback).
+* `bodyOnly` options has been removed. This means by all responses will be of type `Response` (`statusCode`, `headers` and `body`).
+* Added **TypeScript** declaration in `lib/types`.
+* Changed function name from `configureGlobalAgent()` to `globalAgent()`.
+
 ## 0.4.0
 
 * Added support for file downloads. Uses `path` and `filename`, specified in `options`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 * Added support for providing certificate options with HTTPS requests. See further documentation: [https](https://nodejs.org/api/https.html#https_https_request_options_callback) and [tls](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback).
 * `bodyOnly` options has been removed. This means by all responses will be of type `Response` (`statusCode`, `headers` and `body`).
-* Added **TypeScript** declaration.
 * Changed function name from `configureGlobalAgent()` to `globalAgent()`.
+* Can handle file uploads. Pass a read `stream` to `options.body`, or set a file path in `options.path`.
+* Added **TypeScript** declaration.
 
 ## 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Added support for providing certificate options with HTTPS requests. See further documentation: [https](https://nodejs.org/api/https.html#https_https_request_options_callback) and [tls](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback).
 * `bodyOnly` options has been removed. This means by all responses will be of type `Response` (`statusCode`, `headers` and `body`).
-* Added **TypeScript** declaration in `lib/types`.
+* Added **TypeScript** declaration.
 * Changed function name from `configureGlobalAgent()` to `globalAgent()`.
 
 ## 0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.5.0
 
 * Added support for providing certificate options with HTTPS requests. See further documentation: [https](https://nodejs.org/api/https.html#https_https_request_options_callback) and [tls](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback).
+* Added support for using a proxy in requests. `options.proxy` set to the full URL of the proxy.
 * `bodyOnly` options has been removed. This means by all responses will be of type `Response` (`statusCode`, `headers` and `body`).
 * Changed function name from `configureGlobalAgent()` to `globalAgent()`.
 * Can handle file uploads. Pass a read `stream` to `options.body`, or set a file path in `options.path`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2018 Karl Wallenius, Redeploy AB
+Copyright 2019 Karl Wallenius, Redeploy AB
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
 and associated documentation files (the "Software"), to deal in the Software without restriction, 

--- a/lib/types/webreq.d.ts
+++ b/lib/types/webreq.d.ts
@@ -1,0 +1,172 @@
+import webreq = require('./webreq');
+
+interface Buffer {}
+
+class Response {
+    /** Status code of the response */
+    statusCode: number;
+    /** Headers of the response */
+    headers: object;
+    /** Body of the response */
+    body: string|object;
+}
+
+declare interface Agent {
+    /** Keep sockets around for future requests. */
+    keepAlive?: boolean;
+    /** Specifies initial delay for Keep-Alive packets in use with the keepAlive option. */
+    keepAliveMsecs?: number;
+    /**  Maximum number of sockets to allow per host. */
+    maxSockets?: number;
+    /** Maximum number of sockets to leave open if keepAlive is true. */
+    maxFreeSockets?: number;
+    /** Socket timeout in milliseconds. */
+    timeout?: number;
+}
+
+declare interface Certificate {
+    /** Override the trusted CA certificates. */
+    ca?: string[] | Buffer[];
+    /** Certificate chains in PEM format. */
+    cert?: string | string[] | Buffer | Buffer[];
+    /** Private keys in PEM format. If encrypted use together with passphrase. */
+    key?: string | string[] | Buffer | Buffer[];
+    /** Shared passphrase for a private key and/or PFX. */
+    passphrase?: string;
+    /** PFX pr PKCS12 encoded private key and certificate chain. */
+    pfx?: string[] | Buffer[];
+}
+
+declare interface RequestOptions  {
+    /** HTTP method of the request. Default is GET. */
+    method?: string;
+    /** Headers of the request. */
+    headers?: object;
+    /** Data to send with the request. */
+    body?: string | object;
+    /** If true it will check the mime type of the response and output the results accordingly. Default is true.*/
+    parse?: boolean;
+    /** If true it will follow redirects found in the 'location' header. */
+    followRedirects?: boolean;
+    /** Maximum amount of redirects. */
+    maxRedirects?: number;
+    /** When used in a GET request for downloads, it is used as the output path for a file. */
+    path?: string;
+    /** 
+     * Options object for agent for this request.
+     * @param {boolean} [keepAlive] Keep sockets around for future requests.
+     * @param {number} [keepAliveMsecs] Specifies initial delay for Keep-Alive packets in use with the keepAlive option.
+     * @param {number} [maxSockets] Maximum number of sockets to allow per host.
+     * @param {number} [maxFreeSockets] Maximum number of sockets to leave open if keepAlive is true.
+     * @param {number} [timeout] Socket timeout in milliseconds.
+     */
+    agent?: Agent;
+    /** 
+     * Certificate options for the request.
+     * @param {string[] | Buffer[]} [ca] Override the trusted CA certificates.
+     * @param {string[] | Buffer[]} [cert] Certificate chains in PEM format.
+     * @param {string[] | Buffer[]} [key] Private keys in PEM format. If encrypted use together with passphrase.
+     * @param {string} [passphrase] Shared passphrase for a private key and/or PFX.
+     * @param {string[] | Buffer[]} [pfx] PFX pr PKCS12 encoded private key and certificate chain.
+     */
+    certificate: Certificate;
+}
+
+declare class WebReq {
+    constructor();
+    /** Returns response as a stream */
+    stream: boolean;
+    /** If true it will check the mime type of the response and output the results accordingly. Default is true.*/
+    parse: boolean;
+    /** If true it will follow redirects found in the 'location' header. */
+    followRedirects: boolean;
+    /** Maximum amount of redirects. */
+    maxRedirects: Number;
+
+    /**
+    * Performs a HTTP/HTTPS request.
+    * If the optional callback is used it will return a function, if no callback is used it will
+    * return a promise.
+    * 
+    * @param {string} uri URI of the request.
+    * @param {object} [options] Options for the request.
+    * @param {function} [callback] Optional callback function.
+    * @return {function|Promise<Response>}
+    */
+    request(uri: string, options?: RequestOptions, callback?: (err: Error, res: Response) => void): Promise<Response | Error> | void;
+
+    /**
+    * Performs a HTTP/HTTPS GET request.
+    * If the optional callback is used it will return a function, if no callback is used it will
+    * return a promise.
+    * 
+    * @param {string} uri URI of the request.
+    * @param {object} [options] Options for the request.
+    * @param {function} [callback] Optional callback function.
+    * @return {function|Promise<Response>}
+    */
+    get(uri: string, options?: RequestOptions, callback?: (err: Error, res: Response) => void): Promise<Response | Error> | void;
+    
+    /**
+    * Performs a HTTP/HTTPS POST request.
+    * If the optional callback is used it will return a function, if no callback is used it will
+    * return a promise.
+    * 
+    * @param {string} uri URI of the request.
+    * @param {object} [options] Options for the request.
+    * @param {function} [callback] Optional callback function.
+    * @return {function|Promise<Response>}
+    */
+    post(uri: string, options?: RequestOptions, callback?: (err: Error, res: Response) => void): Promise<Response | Error> | void;
+
+    /**
+    * Performs a HTTP/HTTPS PUT request.
+    * If the optional callback is used it will return a function, if no callback is used it will
+    * return a promise.
+    * 
+    * @param {string} uri URI of the request.
+    * @param {object} [options] Options for the request.
+    * @param {function} [callback] Optional callback function.
+    * @return {function|Promise<Response>}
+    */
+    put(uri: string, options?: RequestOptions, callback?: (err: Error, res: Response) => void): Promise<Response | Error> | void;
+
+    /**
+    * Performs a HTTP/HTTPS PATCH request.
+    * If the optional callback is used it will return a function, if no callback is used it will
+    * return a promise.
+    * 
+    * @param {string} uri URI of the request.
+    * @param {object} [options] Options for the request.
+    * @param {function} [callback] Optional callback function.
+    * @return {function|Promise<Response>}
+    */
+    patch(uri: string, options?: RequestOptions, callback?: (err: Error, res: Response) => void): Promise<Response | Error> | void;
+
+    /**
+    * Performs a HTTP/HTTPS DELETE request.
+    * If the optional callback is used it will return a function, if no callback is used it will
+    * return a promise.
+    * 
+    * @param {string} uri URI of the request.
+    * @param {object} [options] Options for the request.
+    * @param {function} [callback] Optional callback function.
+    * @return {function|Promise<Response>}
+    */
+    delete(uri: string, options?: RequestOptions, callback?: (err: Error, res: Response) => void): Promise<Response | Error> | void;
+
+   /**
+   * Configures the global agent for the requests.
+   * If no parameter is passed, it will set default vaules of maxSockets: Infinity, maxFreeSockets: 256.
+   * @param {object} [options] Options object.
+   * @param {number} [options.maxSockets] Maximum number of sockets to allow per host.
+   * @param {number} [options.maxFreeSockets] Maximum number of sockets to leave open if keepAlive is true.
+   * @return {void}
+   */
+    globalAgent(options: object): void;
+}
+
+export let webreq = new WebReq();
+export let Agent = Agent;
+export let Certificate = Certificate;
+export let RequestOptions = RequestOptions;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,16 +16,15 @@ function createRequestOptions(parsedUrl, options) {
   let method = opts.method !== undefined ? opts.method : 'GET';
   let headers = opts.headers !== undefined ? opts.headers : {};
 
+  // Handle POST/PUT/PATCH and Content-Type and Content-Length.
   if ((method === 'POST' || method === 'PUT' || method === 'PATCH') && opts.body !== undefined) {
     if (headers['Content-Type'] === undefined && headers['content-type'] === undefined) {
       headers['Content-Type'] = 'application/json'
     }
 
-    if (!isStream(opts.body) && typeof opts.body !== 'string') {
-      opts.body = JSON.stringify(opts.body);
+    if (headers['Content-Length'] === undefined && headers['content-length'] === undefined) {
+      headers['Content-Length'] = Buffer.byteLength(opts.body);
     }
-
-    headers['Content-Length'] = Buffer.byteLength(opts.body);
   }
 
   let requestOptions = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,21 +6,18 @@ const path = require('path');
 /**
  * Create options for a HTTP/HTTPS request.
  * 
- * @param {string}  parsedUrl Persed URI/URL (using built-in 'url' module) of the request.
- * @param {object}  [options] Options of the request.
- * @param {string}  [options.method] Method of the request.
- * @param {object}  [optons.headers] Headers of the request.
- * 
- * @returns {object}
+ * @param {string} parsedUrl Persed URI/URL (using built-in 'url' module) of the request.
+ * @param {object} [options] Options of the request.
+ * @return {object} Returns object containing request options.
  */
 function createRequestOptions(parsedUrl, options) {
-  let opts = (options !== undefined) ? options : {};
+  let opts = options !== undefined ? options : {};
 
   let method = opts.method !== undefined ? opts.method : 'GET';
   let headers = opts.headers !== undefined ? opts.headers : {};
 
   if ((method === 'POST' || method === 'PUT' || method === 'PATCH') && opts.body !== undefined) {
-    if (headers['Content-Type'] === undefined && headers["content-type"] === undefined) {
+    if (headers['Content-Type'] === undefined && headers['content-type'] === undefined) {
       headers['Content-Type'] = 'application/json'
     }
 
@@ -42,6 +39,15 @@ function createRequestOptions(parsedUrl, options) {
     requestOptions.headers = headers;
   }
 
+  // Check if protocol is HTTPS and if cert options is specified
+  // and see if additional options for sending SSL ceritificates
+  // is present.
+  if (parsedUrl.protocol === 'https:' && opts.certificate) {
+    for (let key in opts.certificate) {
+      requestOptions[key] = opts.certificate[key];
+    }
+  }
+
   return requestOptions;
 }
 
@@ -51,10 +57,9 @@ function createRequestOptions(parsedUrl, options) {
  * it to an object. If no 'Content-Type' is found it will try
  * to determine the body.
  * 
- * @param {object}  headers headers of the response. 
- * @param {array}   body    array of Buffer(s).
- * 
- * @returns {any}    returns depends on mime type of the response.
+ * @param {object} headers Headers of the response.
+ * @param {Array} body Array of Buffer(s).
+ * @return {object|string} Returns string or object depending on mime type of the response.
  */
 function parseResponseBody(headers, body) {
   let mimeType, parsedBody;
@@ -90,7 +95,7 @@ function parseResponseBody(headers, body) {
  * @param {string} outputPath Output path for the file.
  * @param {string} uriPath Parsed path of the requested URL.
  * @param {string} name If specified it will set this name of the file.
- * @returns {string}
+ * @return {string} Returns filename.
  */
 function filename(headers, outputPath, uriPath, name) {
   if (name !== undefined && name !== null) {
@@ -106,7 +111,8 @@ function filename(headers, outputPath, uriPath, name) {
 
 /**
  * Checks if object is a Stream.
- * @param {obiect} obj Object to check.
+ * @param {object} obj Object to check.
+ * @return {boolean} Returns true if it's a Stream.
  */
 function isStream(obj) {
   return obj instanceof Stream;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,7 @@
 
 const Stream = require('stream');
 const path = require('path');
+const url = require('url');
 
 /**
  * Create options for a HTTP/HTTPS request.
@@ -27,10 +28,23 @@ function createRequestOptions(parsedUrl, options) {
     }
   }
 
+  let host = parsedUrl.hostname;
+  let port = parsedUrl.port !== null ? parseInt(parsedUrl.port) : (parsedUrl.protocol === 'https:') ? 443 : 80;
+  let path = parsedUrl.search === null ? parsedUrl.pathname : parsedUrl.pathname + parsedUrl.search;
+
+  // Check for proxy and modify the arguments accordingly.
+  if (opts.proxy) {
+    let parsedProxyUrl = url.parse(opts.proxy);
+    host = parsedProxyUrl.hostname;
+    port = parsedProxyUrl.port;
+    path = parsedUrl.href;
+    headers['Host'] = parsedUrl.protocol + '//' + parsedUrl.host;
+  }
+
   let requestOptions = {
-    hostname: parsedUrl.hostname,
-    port: parsedUrl.port !== null ? parseInt(parsedUrl.port) : (parsedUrl.protocol === 'https:') ? 443 : 80,
-    path: parsedUrl.search === null ? parsedUrl.pathname : parsedUrl.pathname + parsedUrl.search,
+    host: host,
+    port: port,
+    path: path,
     method: method
   };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -22,7 +22,7 @@ function createRequestOptions(parsedUrl, options) {
       headers['Content-Type'] = 'application/json'
     }
 
-    if (headers['Content-Length'] === undefined && headers['content-length'] === undefined) {
+    if (headers['Content-Length'] === undefined && headers['content-length'] === undefined && typeof opts.body === 'string') {
       headers['Content-Length'] = Buffer.byteLength(opts.body);
     }
   }

--- a/lib/webreq.d.ts
+++ b/lib/webreq.d.ts
@@ -1,5 +1,3 @@
-import webreq = require('./webreq');
-
 interface Buffer {}
 
 class Response {
@@ -166,7 +164,9 @@ declare class WebReq {
     globalAgent(options: object): void;
 }
 
-export let webreq = new WebReq();
+//export let webreq = webreq;
+let webreq = new WebReq();
+export = webreq;
 export let Agent = Agent;
 export let Certificate = Certificate;
 export let RequestOptions = RequestOptions;

--- a/lib/webreq.d.ts
+++ b/lib/webreq.d.ts
@@ -119,7 +119,7 @@ interface Buffer {}
 
 declare namespace WebReq {
 
-    declare class Response {
+    class Response {
         /** Status code of the response */
         statusCode: number;
         /** Headers of the response */
@@ -128,33 +128,7 @@ declare namespace WebReq {
         body: string|object;
     }
 
-    declare interface Agent {
-        /** Keep sockets around for future requests. */
-        keepAlive?: boolean;
-        /** Specifies initial delay for Keep-Alive packets in use with the keepAlive option. */
-        keepAliveMsecs?: number;
-        /**  Maximum number of sockets to allow per host. */
-        maxSockets?: number;
-        /** Maximum number of sockets to leave open if keepAlive is true. */
-        maxFreeSockets?: number;
-        /** Socket timeout in milliseconds. */
-        timeout?: number;
-    }
-
-    declare interface Certificate {
-        /** Override the trusted CA certificates. */
-        ca?: string[] | Buffer[];
-        /** Certificate chains in PEM format. */
-        cert?: string | string[] | Buffer | Buffer[];
-        /** Private keys in PEM format. If encrypted use together with passphrase. */
-        key?: string | string[] | Buffer | Buffer[];
-        /** Shared passphrase for a private key and/or PFX. */
-        passphrase?: string;
-        /** PFX pr PKCS12 encoded private key and certificate chain. */
-        pfx?: string[] | Buffer[];
-    }
-
-    declare interface RequestOptions  {
+    interface RequestOptions  {
         /** HTTP method of the request. Default is GET. */
         method?: string;
         /** Headers of the request. */
@@ -167,16 +141,9 @@ declare namespace WebReq {
         followRedirects?: boolean;
         /** Maximum amount of redirects. */
         maxRedirects?: number;
-        /** When used in a GET request for downloads, it is used as the output path for a file. */
+        /** When used in a GET request for downloads, it is used as the output path for a file. When used with POST or PUT it will point to a file to upload. */
         path?: string;
-        /**
-         * Options object for agent for this request.
-         * @param {boolean} [keepAlive] Keep sockets around for future requests.
-         * @param {number} [keepAliveMsecs] Specifies initial delay for Keep-Alive packets in use with the keepAlive option.
-         * @param {number} [maxSockets] Maximum number of sockets to allow per host.
-         * @param {number} [maxFreeSockets] Maximum number of sockets to leave open if keepAlive is true.
-         * @param {number} [timeout] Socket timeout in milliseconds.
-         */
+        /** http.Agent/https.Agent object. */
         agent?: Agent;
         /**
          * Certificate options for the request.
@@ -187,6 +154,23 @@ declare namespace WebReq {
          * @param {string[] | Buffer[]} [pfx] PFX pr PKCS12 encoded private key and certificate chain.
          */
         certificate?: Certificate;
+        /** Proxy to use for the request. */
+        proxy?: string;
+    }
+
+    interface Agent {}
+
+    interface Certificate {
+        /** Override the trusted CA certificates. */
+        ca?: string[] | Buffer[];
+        /** Certificate chains in PEM format. */
+        cert?: string | string[] | Buffer | Buffer[];
+        /** Private keys in PEM format. If encrypted use together with passphrase. */
+        key?: string | string[] | Buffer | Buffer[];
+        /** Shared passphrase for a private key and/or PFX. */
+        passphrase?: string;
+        /** PFX pr PKCS12 encoded private key and certificate chain. */
+        pfx?: string[] | Buffer[];
     }
 }
 

--- a/lib/webreq.d.ts
+++ b/lib/webreq.d.ts
@@ -1,75 +1,3 @@
-interface Buffer {}
-
-class Response {
-    /** Status code of the response */
-    statusCode: number;
-    /** Headers of the response */
-    headers: object;
-    /** Body of the response */
-    body: string|object;
-}
-
-declare interface Agent {
-    /** Keep sockets around for future requests. */
-    keepAlive?: boolean;
-    /** Specifies initial delay for Keep-Alive packets in use with the keepAlive option. */
-    keepAliveMsecs?: number;
-    /**  Maximum number of sockets to allow per host. */
-    maxSockets?: number;
-    /** Maximum number of sockets to leave open if keepAlive is true. */
-    maxFreeSockets?: number;
-    /** Socket timeout in milliseconds. */
-    timeout?: number;
-}
-
-declare interface Certificate {
-    /** Override the trusted CA certificates. */
-    ca?: string[] | Buffer[];
-    /** Certificate chains in PEM format. */
-    cert?: string | string[] | Buffer | Buffer[];
-    /** Private keys in PEM format. If encrypted use together with passphrase. */
-    key?: string | string[] | Buffer | Buffer[];
-    /** Shared passphrase for a private key and/or PFX. */
-    passphrase?: string;
-    /** PFX pr PKCS12 encoded private key and certificate chain. */
-    pfx?: string[] | Buffer[];
-}
-
-declare interface RequestOptions  {
-    /** HTTP method of the request. Default is GET. */
-    method?: string;
-    /** Headers of the request. */
-    headers?: object;
-    /** Data to send with the request. */
-    body?: string | object;
-    /** If true it will check the mime type of the response and output the results accordingly. Default is true.*/
-    parse?: boolean;
-    /** If true it will follow redirects found in the 'location' header. */
-    followRedirects?: boolean;
-    /** Maximum amount of redirects. */
-    maxRedirects?: number;
-    /** When used in a GET request for downloads, it is used as the output path for a file. */
-    path?: string;
-    /** 
-     * Options object for agent for this request.
-     * @param {boolean} [keepAlive] Keep sockets around for future requests.
-     * @param {number} [keepAliveMsecs] Specifies initial delay for Keep-Alive packets in use with the keepAlive option.
-     * @param {number} [maxSockets] Maximum number of sockets to allow per host.
-     * @param {number} [maxFreeSockets] Maximum number of sockets to leave open if keepAlive is true.
-     * @param {number} [timeout] Socket timeout in milliseconds.
-     */
-    agent?: Agent;
-    /** 
-     * Certificate options for the request.
-     * @param {string[] | Buffer[]} [ca] Override the trusted CA certificates.
-     * @param {string[] | Buffer[]} [cert] Certificate chains in PEM format.
-     * @param {string[] | Buffer[]} [key] Private keys in PEM format. If encrypted use together with passphrase.
-     * @param {string} [passphrase] Shared passphrase for a private key and/or PFX.
-     * @param {string[] | Buffer[]} [pfx] PFX pr PKCS12 encoded private key and certificate chain.
-     */
-    certificate: Certificate;
-}
-
 declare class WebReq {
     constructor();
     /** Returns response as a stream */
@@ -89,9 +17,13 @@ declare class WebReq {
     * @param {string} uri URI of the request.
     * @param {object} [options] Options for the request.
     * @param {function} [callback] Optional callback function.
-    * @return {function|Promise<Response>}
+    * @return {function|Promise<WebReq.Response>}
     */
-    request(uri: string, options?: RequestOptions, callback?: (err: Error, res: Response) => void): Promise<Response | Error> | void;
+    request(
+        uri: string,
+        options?: WebReq.RequestOptions,
+        callback?: (err: Error, res: WebReq.Response) => void
+    ): Promise<WebReq.Response | Error> | void;
 
     /**
     * Performs a HTTP/HTTPS GET request.
@@ -101,9 +33,12 @@ declare class WebReq {
     * @param {string} uri URI of the request.
     * @param {object} [options] Options for the request.
     * @param {function} [callback] Optional callback function.
-    * @return {function|Promise<Response>}
+    * @return {function|Promise<WebReq.Response>}
     */
-    get(uri: string, options?: RequestOptions, callback?: (err: Error, res: Response) => void): Promise<Response | Error> | void;
+    get(uri: string,
+        options?: WebReq.RequestOptions,
+        callback?: (err: Error, res: WebReq.Response) => void
+    ): Promise<WebReq.Response | Error> | void;
     
     /**
     * Performs a HTTP/HTTPS POST request.
@@ -113,9 +48,13 @@ declare class WebReq {
     * @param {string} uri URI of the request.
     * @param {object} [options] Options for the request.
     * @param {function} [callback] Optional callback function.
-    * @return {function|Promise<Response>}
+    * @return {function|Promise<WebReq.Response>}
     */
-    post(uri: string, options?: RequestOptions, callback?: (err: Error, res: Response) => void): Promise<Response | Error> | void;
+    post(
+        uri: string,
+        options?: WebReq.RequestOptions,
+        callback?: (err: Error, res: WebReq.Response) => void
+    ): Promise<WebReq.Response | Error> | void;
 
     /**
     * Performs a HTTP/HTTPS PUT request.
@@ -125,9 +64,13 @@ declare class WebReq {
     * @param {string} uri URI of the request.
     * @param {object} [options] Options for the request.
     * @param {function} [callback] Optional callback function.
-    * @return {function|Promise<Response>}
+    * @return {function|Promise<WebReq.Response>}
     */
-    put(uri: string, options?: RequestOptions, callback?: (err: Error, res: Response) => void): Promise<Response | Error> | void;
+    put(
+        uri: string,
+        options?: WebReq.RequestOptions,
+        callback?: (err: Error, res: WebReq.Response) => void
+    ): Promise<WebReq.Response | Error> | void;
 
     /**
     * Performs a HTTP/HTTPS PATCH request.
@@ -137,9 +80,13 @@ declare class WebReq {
     * @param {string} uri URI of the request.
     * @param {object} [options] Options for the request.
     * @param {function} [callback] Optional callback function.
-    * @return {function|Promise<Response>}
+    * @return {function|Promise<WebReq.Response>}
     */
-    patch(uri: string, options?: RequestOptions, callback?: (err: Error, res: Response) => void): Promise<Response | Error> | void;
+    patch(
+        uri: string,
+        options?: WebReq.RequestOptions,
+        callback?: (err: Error, res: WebReq.Response) => void
+    ): Promise<WebReq.Response | Error> | void;
 
     /**
     * Performs a HTTP/HTTPS DELETE request.
@@ -149,9 +96,13 @@ declare class WebReq {
     * @param {string} uri URI of the request.
     * @param {object} [options] Options for the request.
     * @param {function} [callback] Optional callback function.
-    * @return {function|Promise<Response>}
+    * @return {function|Promise<WebReq.Response>}
     */
-    delete(uri: string, options?: RequestOptions, callback?: (err: Error, res: Response) => void): Promise<Response | Error> | void;
+    delete(
+        uri: string,
+        options?: WebReq.RequestOptions,
+        callback?: (err: Error, res: WebReq.Response) => void
+    ): Promise<WebReq.Response | Error> | void;
 
    /**
    * Configures the global agent for the requests.
@@ -164,9 +115,79 @@ declare class WebReq {
     globalAgent(options: object): void;
 }
 
-//export let webreq = webreq;
-let webreq = new WebReq();
-export = webreq;
-export let Agent = Agent;
-export let Certificate = Certificate;
-export let RequestOptions = RequestOptions;
+interface Buffer {}
+
+declare namespace WebReq {
+
+    declare class Response {
+        /** Status code of the response */
+        statusCode: number;
+        /** Headers of the response */
+        headers: object;
+        /** Body of the response */
+        body: string|object;
+    }
+
+    declare interface Agent {
+        /** Keep sockets around for future requests. */
+        keepAlive?: boolean;
+        /** Specifies initial delay for Keep-Alive packets in use with the keepAlive option. */
+        keepAliveMsecs?: number;
+        /**  Maximum number of sockets to allow per host. */
+        maxSockets?: number;
+        /** Maximum number of sockets to leave open if keepAlive is true. */
+        maxFreeSockets?: number;
+        /** Socket timeout in milliseconds. */
+        timeout?: number;
+    }
+
+    declare interface Certificate {
+        /** Override the trusted CA certificates. */
+        ca?: string[] | Buffer[];
+        /** Certificate chains in PEM format. */
+        cert?: string | string[] | Buffer | Buffer[];
+        /** Private keys in PEM format. If encrypted use together with passphrase. */
+        key?: string | string[] | Buffer | Buffer[];
+        /** Shared passphrase for a private key and/or PFX. */
+        passphrase?: string;
+        /** PFX pr PKCS12 encoded private key and certificate chain. */
+        pfx?: string[] | Buffer[];
+    }
+
+    declare interface RequestOptions  {
+        /** HTTP method of the request. Default is GET. */
+        method?: string;
+        /** Headers of the request. */
+        headers?: object;
+        /** Data to send with the request. */
+        body?: string | object;
+        /** If true it will check the mime type of the response and output the results accordingly. Default is true.*/
+        parse?: boolean;
+        /** If true it will follow redirects found in the 'location' header. */
+        followRedirects?: boolean;
+        /** Maximum amount of redirects. */
+        maxRedirects?: number;
+        /** When used in a GET request for downloads, it is used as the output path for a file. */
+        path?: string;
+        /**
+         * Options object for agent for this request.
+         * @param {boolean} [keepAlive] Keep sockets around for future requests.
+         * @param {number} [keepAliveMsecs] Specifies initial delay for Keep-Alive packets in use with the keepAlive option.
+         * @param {number} [maxSockets] Maximum number of sockets to allow per host.
+         * @param {number} [maxFreeSockets] Maximum number of sockets to leave open if keepAlive is true.
+         * @param {number} [timeout] Socket timeout in milliseconds.
+         */
+        agent?: Agent;
+        /**
+         * Certificate options for the request.
+         * @param {string[] | Buffer[]} [ca] Override the trusted CA certificates.
+         * @param {string[] | Buffer[]} [cert] Certificate chains in PEM format.
+         * @param {string[] | Buffer[]} [key] Private keys in PEM format. If encrypted use together with passphrase.
+         * @param {string} [passphrase] Shared passphrase for a private key and/or PFX.
+         * @param {string[] | Buffer[]} [pfx] PFX pr PKCS12 encoded private key and certificate chain.
+         */
+        certificate?: Certificate;
+    }
+}
+
+export = new WebReq();

--- a/lib/webreq.js
+++ b/lib/webreq.js
@@ -3,7 +3,6 @@
 const http = require('http');
 const https = require('https');
 const url = require('url');
-const Readable = require('stream').Readable;
 
 const Response = require('./response');
 const { createRequestOptions, parseResponseBody, filename } = require('./utils');
@@ -11,14 +10,12 @@ const { createRequestOptions, parseResponseBody, filename } = require('./utils')
 /**
  * Used to make HTTP/HTTPS requests.
  * @class
- * 
- * @returns an instance of itself.
+ * @return an instance of itself.
  */
 class WebReq {
   constructor() {
     this.stream = false;
     this.parse = true;
-    this.bodyOnly = true;
     this.followRedirects = false;
     this.maxRedirects = 3;
   }
@@ -31,13 +28,11 @@ class WebReq {
    * @param {string} uri URI of the request.
    * @param {object} [options] Options for the request.
    * @param {string} [options.method] HTTP method of the request. Default is GET.
-   * @param {object} [options.headers] Additional headers of the request.
+   * @param {object} [options.headers] Headers of the request.
    * @param {boolean} [options.stream] Returns response as a stream.
    * @param {string|object} [options.body] Data to send with the request.
    * @param {boolean} [options.parse] If true it will check the mime type of the response
    * and output the results accordingly. Default is true.
-   * @param {boolean} [options.bodyOnly] If true it will only respond with the body, if false
-   * it will return an object, Response, which contains statusCode, headers and body.
    * @param {boolean} [options.followRedirects] If true it will follow redirects found in the
    * 'location' header.
    * @param {number} [options.maxRedirects] Maximum amount of redirects.
@@ -53,9 +48,16 @@ class WebReq {
    * @param {number} [options.agent.maxFreeSockets] Maximum number of sockets to leave open
    * if keepAlive is true.
    * @param {number} [options.agent.timeout] Socket timeout in milliseconds.
-   * @param {function} [callback] 
-   * 
-   * @returns {function|Promise}
+   * @param {object} [options.certificate] Certificate options for the request (HTTPS).
+   * @param {string|Buffer} [options.certificate.ca] Override the trusted CA certificates.
+   * @param {string|Buffer} [options.certificate.cert] Certificate chains in PEM format.
+   * @param {string|Buffer} [options.certificate.key] Private keys in PEM format. If encrypted
+   * use together with options.certificate.passphrase.
+   * @param {string} [options.certificate.passphrase] Shared passphrase for a private key and/or PFX.
+   * @param {string|Buffer|Array} [options.certificate.pfx] PFX pr PKCS12 encoded private key and
+   * certificate chain.
+   * @param {function} [callback] Optional callback funtion.
+   * @return {function|Promise} Returns a Promise which resolves to a Response object if no callback is provided.
    */
   request(uri, options, callback) {
 
@@ -68,7 +70,6 @@ class WebReq {
 
     opts.stream = opts.stream === undefined ? this.stream : opts.stream;
     opts.parse = opts.parse === undefined ? this.parse : opts.parse;
-    opts.bodyOnly = opts.bodyOnly === undefined ? this.bodyOnly : opts.bodyOnly;
     opts.followRedirects = opts.followRedirects === undefined ? this.followRedirects : opts.followRedirects;
     opts.maxRedirects = opts.maxRedirects === undefined ? this.maxRedirects : opts.maxRedirects;
 
@@ -97,13 +98,11 @@ class WebReq {
    * @param {string} uri URI of the request.
    * @param {object} [options] Options for the request.
    * @param {string} [options.method] HTTP method of the request. Enforces GET.
-   * @param {object} [options.headers] Additional headers of the request.
+   * @param {object} [options.headers] Headers of the request.
    * @param {boolean} [options.stream] Returns response as a stream.
-   * @param {any} [options.body] Data to send with the request.
+   * @param {string|object} [options.body] Data to send with the request.
    * @param {boolean} [options.parse] If true it will check the mime type of the response
    * and output the results accordingly. Default is true.
-   * @param {boolean} [options.bodyOnly] If true it will only respond with the body, if false
-   * it will return an object, Response, which contains statusCode, headers and body.
    * @param {boolean} [options.followRedirects] If true it will follow redirects found in the
    * 'location' header.
    * @param {number} [options.maxRedirects] Maximum amount of redirects.
@@ -119,9 +118,16 @@ class WebReq {
    * @param {number} [options.agent.maxFreeSockets] Maximum number of sockets to leave open
    * if keepAlive is true.
    * @param {number} [options.agent.timeout] Socket timeout in milliseconds.
-   * @param {function} [callback] 
-   * 
-   * @returns {function|Promise}
+   * @param {object} [options.certificate] Certificate options for the request (HTTPS).
+   * @param {string|Buffer} [options.certificate.ca] Override the trusted CA certificates.
+   * @param {string|Buffer} [options.certificate.cert] Certificate chains in PEM format.
+   * @param {string|Buffer} [options.certificate.key] Private keys in PEM format. If encrypted
+   * use together with options.certificate.passphrase.
+   * @param {string} [options.certificate.passphrase] Shared passphrase for a private key and/or PFX.
+   * @param {string|Buffer|Array} [options.certificate.pfx] PFX pr PKCS12 encoded private key and
+   * certificate chain.
+   * @param {function} [callback] Optional callback funtion.
+   * @return {function|Promise} Returns a Promise which resolves to a Response object if no callback is provided.
    */
   get(uri, options, callback) {
 
@@ -141,13 +147,11 @@ class WebReq {
    * @param {string} uri URI of the request.
    * @param {object} [options] Options for the request.
    * @param {string} [options.method] HTTP method of the request. Enforces POST.
-   * @param {object} [options.headers] Additional headers of the request.
+   * @param {object} [options.headers] Headers of the request.
    * @param {boolean} [options.stream] Returns response as a stream.
    * @param {string|object} [options.body] Data to send with the request.
    * @param {boolean} [options.parse] If true it will check the mime type of the response
    * and output the results accordingly. Default is true.
-   * @param {boolean} [options.bodyOnly] If true it will only respond with the body, if false
-   * it will return an object, Response, which contains statusCode, headers and body.
    * @param {boolean} [options.followRedirects] If true it will follow redirects found in the
    * 'location' header.
    * @param {number} [options.maxRedirects] Maximum amount of redirects.
@@ -159,9 +163,16 @@ class WebReq {
    * @param {number} [options.agent.maxFreeSockets] Maximum number of sockets to leave open
    * if keepAlive is true.
    * @param {number} [options.agent.timeout] Socket timeout in milliseconds.
-   * @param {function} [callback] 
-   * 
-   * @returns {function|Promise}
+   * @param {object} [options.certificate] Certificate options for the request (HTTPS).
+   * @param {string|Buffer} [options.certificate.ca] Override the trusted CA certificates.
+   * @param {string|Buffer} [options.certificate.cert] Certificate chains in PEM format.
+   * @param {string|Buffer} [options.certificate.key] Private keys in PEM format. If encrypted
+   * use together with options.certificate.passphrase.
+   * @param {string} [options.certificate.passphrase] Shared passphrase for a private key and/or PFX.
+   * @param {string|Buffer|Array} [options.certificate.pfx] PFX pr PKCS12 encoded private key and
+   * certificate chain.
+   * @param {function} [callback] Optional callback funtion.
+   * @return {function|Promise} Returns a Promise which resolves to a Response object if no callback is provided.
    */
   post(uri, options, callback) {
 
@@ -183,13 +194,11 @@ class WebReq {
    * @param {string} uri URI of the request.
    * @param {object} [options] Options for the request.
    * @param {string} [options.method] HTTP method of the request. Enforces PUT.
-   * @param {object} [options.headers] Additional headers of the request.
+   * @param {object} [options.headers] Headers of the request.
    * @param {boolean} [options.stream] Returns response as a stream.
-   * @param {any} [options.body] Data to send with the request.
+   * @param {string|object} [options.body] Data to send with the request.
    * @param {boolean} [options.parse] If true it will check the mime type of the response
    * and output the results accordingly. Default is true.
-   * @param {boolean} [options.bodyOnly] If true it will only respond with the body, if false
-   * it will return an object, Response, which contains statusCode, headers and body.
    * @param {boolean} [options.followRedirects] If true it will follow redirects found in the
    * 'location' header.
    * @param {number} [options.maxRedirects] Maximum amount of redirects.
@@ -201,9 +210,16 @@ class WebReq {
    * @param {number} [options.agent.maxFreeSockets] Maximum number of sockets to leave open
    * if keepAlive is true.
    * @param {number} [options.agent.timeout] Socket timeout in milliseconds.
-   * @param {function} [callback] 
-   * 
-   * @returns {function|Promise}
+   * @param {object} [options.certificate] Certificate options for the request (HTTPS).
+   * @param {string|Buffer} [options.certificate.ca] Override the trusted CA certificates.
+   * @param {string|Buffer} [options.certificate.cert] Certificate chains in PEM format.
+   * @param {string|Buffer} [options.certificate.key] Private keys in PEM format. If encrypted
+   * use together with options.certificate.passphrase.
+   * @param {string} [options.certificate.passphrase] Shared passphrase for a private key and/or PFX.
+   * @param {string|Buffer|Array} [options.certificate.pfx] PFX pr PKCS12 encoded private key and
+   * certificate chain.
+   * @param {function} [callback] Optional callback funtion.
+   * @return {function|Promise} Returns a Promise which resolves to a Response object if no callback is provided.
    */
   put(uri, options, callback) {
 
@@ -225,13 +241,11 @@ class WebReq {
    * @param {string} uri URI of the request.
    * @param {object} [options] Options for the request.
    * @param {string} [options.method] HTTP method of the request. Enforces PATCH.
-   * @param {object} [options.headers] Additional headers of the request.
+   * @param {object} [options.headers] Headers of the request.
    * @param {boolean} [options.stream] Returns response as a stream.
    * @param {string|object} [options.body] Data to send with the request.
    * @param {boolean} [options.parse] If true it will check the mime type of the response
    * and output the results accordingly. Default is true.
-   * @param {boolean} [options.bodyOnly] If true it will only respond with the body, if false
-   * it will return an object, Response, which contains statusCode, headers and body.
    * @param {boolean} [options.followRedirects] If true it will follow redirects found in the
    * 'location' header.
    * @param {number} [options.maxRedirects] Maximum amount of redirects.
@@ -243,9 +257,16 @@ class WebReq {
    * @param {number} [options.agent.maxFreeSockets] Maximum number of sockets to leave open
    * if keepAlive is true.
    * @param {number} [options.agent.timeout] Socket timeout in milliseconds.
-   * @param {function} [callback] 
-   * 
-   * @returns {function|Promise}
+   * @param {object} [options.certificate] Certificate options for the request (HTTPS).
+   * @param {string|Buffer} [options.certificate.ca] Override the trusted CA certificates.
+   * @param {string|Buffer} [options.certificate.cert] Certificate chains in PEM format.
+   * @param {string|Buffer} [options.certificate.key] Private keys in PEM format. If encrypted
+   * use together with options.certificate.passphrase.
+   * @param {string} [options.certificate.passphrase] Shared passphrase for a private key and/or PFX.
+   * @param {string|Buffer|Array} [options.certificate.pfx] PFX pr PKCS12 encoded private key and
+   * certificate chain.
+   * @param {function} [callback] Optional callback funtion.
+   * @return {function|Promise} Returns a Promise which resolves to a Response object if no callback is provided.
    */
   patch(uri, options, callback) {
 
@@ -267,13 +288,14 @@ class WebReq {
    * @param {string} uri URI of the request.
    * @param {object} [options] Options for the request.
    * @param {string} [options.method] HTTP method of the request. Enforces DELETE.
-   * @param {object} [options.headers] Additional headers of the request.
+   * @param {object} [options.headers] Headers of the request.
    * @param {boolean} [options.stream] Returns response as a stream.
    * @param {string|object} [options.body] Data to send with the request.
    * @param {boolean} [options.parse] If true it will check the mime type of the response
    * and output the results accordingly. Default is true.
-   * @param {boolean} [options.bodyOnly] If true it will only respond with the body, if false
-   * it will return an object, Response, which contains statusCode, headers and body.
+   * @param {boolean} [options.followRedirects] If true it will follow redirects found in the
+   * 'location' header.
+   * @param {number} [options.maxRedirects] Maximum amount of redirects.
    * @param {object} [options.agent] Options object for agent for this request.
    * @param {boolean} [options.agent.keepAlive] Keep sockets around for future requests.
    * @param {number} [options.agent.keepAliveMsecs] Specifies initial delay for Keep-Alive
@@ -282,9 +304,16 @@ class WebReq {
    * @param {number} [options.agent.maxFreeSockets] Maximum number of sockets to leave open
    * if keepAlive is true.
    * @param {number} [options.agent.timeout] Socket timeout in milliseconds.
-   * @param {function} [callback] 
-   * 
-   * @returns {function|Promise}
+   * @param {object} [options.certificate] Certificate options for the request (HTTPS).
+   * @param {string|Buffer} [options.certificate.ca] Override the trusted CA certificates.
+   * @param {string|Buffer} [options.certificate.cert] Certificate chains in PEM format.
+   * @param {string|Buffer} [options.certificate.key] Private keys in PEM format. If encrypted
+   * use together with options.certificate.passphrase.
+   * @param {string} [options.certificate.passphrase] Shared passphrase for a private key and/or PFX.
+   * @param {string|Buffer|Array} [options.certificate.pfx] PFX pr PKCS12 encoded private key and
+   * certificate chain.
+   * @param {function} [callback] Optional callback funtion.
+   * @return {function|Promise} Returns a Promise which resolves to a Response object if no callback is provided.
    */
   delete(uri, options, callback) {
 
@@ -305,7 +334,7 @@ class WebReq {
    * @param {number} [options.maxSockets] Maximum number of sockets to allow per host.
    * @param {number} [options.maxFreeSockets] Maximum number of sockets to leave open if keepAlive is true.
    */
-  configureGlobalAgent(options) {
+  globalAgent(options) {
     let opts = options !== undefined ? options : {};
 
     if (opts.maxSockets !== undefined) {
@@ -326,8 +355,7 @@ class WebReq {
  * @param {string} uri URI of the request.
  * @param {object} [options] Options for the request.
  * @param {function} [callback]
- * 
- * @returns {function}
+ * @return {function}
  */
 function _request(uri, options, callback) {
 
@@ -386,8 +414,7 @@ function _responseHandler(res, options, callback) {
 
   res.on('end', () => {
     let body = options.parse ? parseResponseBody(res.headers, data) : Buffer.concat(data).toString();
-    let response = options.bodyOnly === true ? body : new Response(res.statusCode, res.headers, body);
-    callback(null, response);
+    callback(null, new Response(res.statusCode, res.headers, body));
   });
 }
 
@@ -412,9 +439,7 @@ function _responseFileHandler(res, options, path, callback) {
 
   res.on('end', () => {
     data.end();
-
-    let response = options.bodyOnly === true ? null : new Response(res.statusCode, res.headers, null);
-    callback(null, response);
+    callback(null, new Response(res.statusCode, res.headers, null));
   });
 }
 

--- a/lib/webreq.js
+++ b/lib/webreq.js
@@ -78,7 +78,7 @@ class WebReq {
     // Handle body options. Stringify if options is JSON object and not a stream.
     if (opts.body && !isStream(opts.body) && !Buffer.isBuffer(opts.body) && typeof opts.body !== 'string') {
       opts.body = JSON.stringify(opts.body);
-    } else if ((opts.method === 'POST'|| opts.method === 'PUT') && opts.path) {
+    } else if ((opts.method === 'POST' || opts.method === 'PUT') && opts.path) {
       opts.body = fs.createReadStream(opts.path);
     }
 
@@ -232,7 +232,7 @@ class WebReq {
 
     if (!callback && typeof options === 'function') {
       callback = options;
-      options = undefined
+      options = undefined;
     }
 
     let opts = options !== undefined ? options : { method: 'PUT' };

--- a/lib/webreq.js
+++ b/lib/webreq.js
@@ -3,6 +3,7 @@
 const http = require('http');
 const https = require('https');
 const url = require('url');
+const fs = require('fs');
 
 const Response = require('./response');
 const { createRequestOptions, filename, isStream, parseResponseBody } = require('./utils');
@@ -67,7 +68,7 @@ class WebReq {
     }
 
     let opts = options !== undefined ? options : { method: 'GET' };
-
+    // Handle options and set default values.
     opts.stream = opts.stream === undefined ? this.stream : opts.stream;
     opts.parse = opts.parse === undefined ? this.parse : opts.parse;
     opts.followRedirects = opts.followRedirects === undefined ? this.followRedirects : opts.followRedirects;
@@ -75,8 +76,10 @@ class WebReq {
     opts.redirects = 0;
 
     // Handle body options. Stringify if options is JSON object and not a stream.
-    if (opts.body && !isStream(opts.body) && typeof opts.body !== 'string') {
+    if (opts.body && !isStream(opts.body) && !Buffer.isBuffer(opts.body) && typeof opts.body !== 'string') {
       opts.body = JSON.stringify(opts.body);
+    } else if ((opts.method === 'POST'|| opts.method === 'PUT') && opts.path) {
+      opts.body = fs.createReadStream(opts.path);
     }
 
     if (!callback) {
@@ -383,8 +386,8 @@ function _request(uri, options, callback) {
     }
     // Determine way of handling response.
     if (options.stream) {
-      _responseStreamHandler(res, callback);
-    } else if (options.path) {
+      callback(null, res);
+    } else if (options.path && requestOptions.method === 'GET') {
       _responseFileHandler(res, options, parsedUrl.path, callback);
     } else {
       _responseHandler(res, options, callback);
@@ -397,10 +400,10 @@ function _request(uri, options, callback) {
 
   // Handle request body.
   if (options.body) {
-    req.write(options.body);
+    _requestWriter(req, options.body);
+  } else {
+    req.end();
   }
-
-  req.end();
 }
 
 /**
@@ -412,7 +415,7 @@ function _request(uri, options, callback) {
 function _responseHandler(res, options, callback) {
 
   let data = [];
-  res.on('data', (d) => {
+  res.on('data', d => {
     data.push(d);
   });
 
@@ -437,7 +440,7 @@ function _responseFileHandler(res, options, path, callback) {
   let outputPath = filename(res.headers, options.path, path, fname);
 
   let data = fs.createWriteStream(outputPath);
-  res.on('data', (d) => {
+  res.on('data', d => {
     data.write(d);
   });
 
@@ -447,13 +450,16 @@ function _responseFileHandler(res, options, path, callback) {
   });
 }
 
-/**
- * Outputs response to a stream.
- * @param {object} res Response object to handle.
- * @param {function} callback Callback function.
- */
-function _responseStreamHandler(res, callback) {
-  callback(null, res);
+function _requestWriter(req, data) {
+  if (isStream(data)) {
+    data.on('data', d => {
+      req.write(d);
+    }).on('end', () => {
+      req.end();
+    });
+  } else {
+    req.write(data);
+  }
 }
 
 module.exports = new WebReq();

--- a/lib/webreq.js
+++ b/lib/webreq.js
@@ -41,14 +41,7 @@ class WebReq {
    * output path for a file.
    * @param {string} [options.filename] Used together with path, if a new custom filename is
    * to be used.
-   * @param {object} [options.agent] Options object for agent for this request.
-   * @param {boolean} [options.agent.keepAlive] Keep sockets around for future requests.
-   * @param {number} [options.agent.keepAliveMsecs] Specifies initial delay for Keep-Alive
-   * packets in use with the keepAlive option.
-   * @param {number} [options.agent.maxSockets] Maximum number of sockets to allow per host.
-   * @param {number} [options.agent.maxFreeSockets] Maximum number of sockets to leave open
-   * if keepAlive is true.
-   * @param {number} [options.agent.timeout] Socket timeout in milliseconds.
+   * @param {object} [options.agent] http.Agent/https.Agent object.
    * @param {object} [options.certificate] Certificate options for the request (HTTPS).
    * @param {string|Buffer} [options.certificate.ca] Override the trusted CA certificates.
    * @param {string|Buffer} [options.certificate.cert] Certificate chains in PEM format.
@@ -57,6 +50,7 @@ class WebReq {
    * @param {string} [options.certificate.passphrase] Shared passphrase for a private key and/or PFX.
    * @param {string|Buffer|Array} [options.certificate.pfx] PFX pr PKCS12 encoded private key and
    * certificate chain.
+   * @param {string} [options.proxy] Proxy to use for the request.
    * @param {function} [callback] Optional callback funtion.
    * @return {function|Promise} Returns a Promise which resolves to a Response object if no callback is provided.
    */
@@ -114,17 +108,10 @@ class WebReq {
    * 'location' header.
    * @param {number} [options.maxRedirects] Maximum amount of redirects.
    * @param {string} [options.path] When used in a GET request for downloads, it is used as the
-   * output path for a file.
+   * output path for a file. When used with POST or PUT it will point to a file to upload.
    * @param {string} [options.filename] Used together with path, if a new custom filename is
    * to be used.
-   * @param {object} [options.agent] Options object for agent for this request.
-   * @param {boolean} [options.agent.keepAlive] Keep sockets around for future requests.
-   * @param {number} [options.agent.keepAliveMsecs] Specifies initial delay for Keep-Alive
-   * packets in use with the keepAlive option.
-   * @param {number} [options.agent.maxSockets] Maximum number of sockets to allow per host.
-   * @param {number} [options.agent.maxFreeSockets] Maximum number of sockets to leave open
-   * if keepAlive is true.
-   * @param {number} [options.agent.timeout] Socket timeout in milliseconds.
+   * @param {object} [options.agent] http.Agent/https.Agent object.
    * @param {object} [options.certificate] Certificate options for the request (HTTPS).
    * @param {string|Buffer} [options.certificate.ca] Override the trusted CA certificates.
    * @param {string|Buffer} [options.certificate.cert] Certificate chains in PEM format.
@@ -133,6 +120,7 @@ class WebReq {
    * @param {string} [options.certificate.passphrase] Shared passphrase for a private key and/or PFX.
    * @param {string|Buffer|Array} [options.certificate.pfx] PFX pr PKCS12 encoded private key and
    * certificate chain.
+   * @param {string} [options.proxy] Proxy to use for the request.
    * @param {function} [callback] Optional callback funtion.
    * @return {function|Promise} Returns a Promise which resolves to a Response object if no callback is provided.
    */
@@ -162,14 +150,9 @@ class WebReq {
    * @param {boolean} [options.followRedirects] If true it will follow redirects found in the
    * 'location' header.
    * @param {number} [options.maxRedirects] Maximum amount of redirects.
-   * @param {object} [options.agent] Options object for agent for this request.
-   * @param {boolean} [options.agent.keepAlive] Keep sockets around for future requests.
-   * @param {number} [options.agent.keepAliveMsecs] Specifies initial delay for Keep-Alive
-   * packets in use with the keepAlive option.
-   * @param {number} [options.agent.maxSockets] Maximum number of sockets to allow per host.
-   * @param {number} [options.agent.maxFreeSockets] Maximum number of sockets to leave open
-   * if keepAlive is true.
-   * @param {number} [options.agent.timeout] Socket timeout in milliseconds.
+   * @param {string} [options.path] When used in a GET request for downloads, it is used as the
+   * output path for a file. When used with POST or PUT it will point to a file to upload.
+   * @param {object} [options.agent] http.Agent/https.Agent object.
    * @param {object} [options.certificate] Certificate options for the request (HTTPS).
    * @param {string|Buffer} [options.certificate.ca] Override the trusted CA certificates.
    * @param {string|Buffer} [options.certificate.cert] Certificate chains in PEM format.
@@ -178,6 +161,7 @@ class WebReq {
    * @param {string} [options.certificate.passphrase] Shared passphrase for a private key and/or PFX.
    * @param {string|Buffer|Array} [options.certificate.pfx] PFX pr PKCS12 encoded private key and
    * certificate chain.
+   * @param {string} [options.proxy] Proxy to use for the request.
    * @param {function} [callback] Optional callback funtion.
    * @return {function|Promise} Returns a Promise which resolves to a Response object if no callback is provided.
    */
@@ -209,14 +193,9 @@ class WebReq {
    * @param {boolean} [options.followRedirects] If true it will follow redirects found in the
    * 'location' header.
    * @param {number} [options.maxRedirects] Maximum amount of redirects.
-   * @param {object} [options.agent] Options object for agent for this request.
-   * @param {boolean} [options.agent.keepAlive] Keep sockets around for future requests.
-   * @param {number} [options.agent.keepAliveMsecs] Specifies initial delay for Keep-Alive
-   * packets in use with the keepAlive option.
-   * @param {number} [options.agent.maxSockets] Maximum number of sockets to allow per host.
-   * @param {number} [options.agent.maxFreeSockets] Maximum number of sockets to leave open
-   * if keepAlive is true.
-   * @param {number} [options.agent.timeout] Socket timeout in milliseconds.
+   * @param {string} [options.path] When used in a GET request for downloads, it is used as the
+   * output path for a file. When used with POST or PUT it will point to a file to upload.
+   * @param {object} [options.agent] http.Agent/https.Agent object.
    * @param {object} [options.certificate] Certificate options for the request (HTTPS).
    * @param {string|Buffer} [options.certificate.ca] Override the trusted CA certificates.
    * @param {string|Buffer} [options.certificate.cert] Certificate chains in PEM format.
@@ -225,6 +204,7 @@ class WebReq {
    * @param {string} [options.certificate.passphrase] Shared passphrase for a private key and/or PFX.
    * @param {string|Buffer|Array} [options.certificate.pfx] PFX pr PKCS12 encoded private key and
    * certificate chain.
+   * @param {string} [options.proxy] Proxy to use for the request.
    * @param {function} [callback] Optional callback funtion.
    * @return {function|Promise} Returns a Promise which resolves to a Response object if no callback is provided.
    */
@@ -256,14 +236,7 @@ class WebReq {
    * @param {boolean} [options.followRedirects] If true it will follow redirects found in the
    * 'location' header.
    * @param {number} [options.maxRedirects] Maximum amount of redirects.
-   * @param {object} [options.agent] Options object for agent for this request.
-   * @param {boolean} [options.agent.keepAlive] Keep sockets around for future requests.
-   * @param {number} [options.agent.keepAliveMsecs] Specifies initial delay for Keep-Alive
-   * packets in use with the keepAlive option.
-   * @param {number} [options.agent.maxSockets] Maximum number of sockets to allow per host.
-   * @param {number} [options.agent.maxFreeSockets] Maximum number of sockets to leave open
-   * if keepAlive is true.
-   * @param {number} [options.agent.timeout] Socket timeout in milliseconds.
+   * @param {object} [options.agent] http.Agent/https.Agent object.
    * @param {object} [options.certificate] Certificate options for the request (HTTPS).
    * @param {string|Buffer} [options.certificate.ca] Override the trusted CA certificates.
    * @param {string|Buffer} [options.certificate.cert] Certificate chains in PEM format.
@@ -272,6 +245,7 @@ class WebReq {
    * @param {string} [options.certificate.passphrase] Shared passphrase for a private key and/or PFX.
    * @param {string|Buffer|Array} [options.certificate.pfx] PFX pr PKCS12 encoded private key and
    * certificate chain.
+   * @param {string} [options.proxy] Proxy to use for the request.
    * @param {function} [callback] Optional callback funtion.
    * @return {function|Promise} Returns a Promise which resolves to a Response object if no callback is provided.
    */
@@ -303,14 +277,7 @@ class WebReq {
    * @param {boolean} [options.followRedirects] If true it will follow redirects found in the
    * 'location' header.
    * @param {number} [options.maxRedirects] Maximum amount of redirects.
-   * @param {object} [options.agent] Options object for agent for this request.
-   * @param {boolean} [options.agent.keepAlive] Keep sockets around for future requests.
-   * @param {number} [options.agent.keepAliveMsecs] Specifies initial delay for Keep-Alive
-   * packets in use with the keepAlive option.
-   * @param {number} [options.agent.maxSockets] Maximum number of sockets to allow per host.
-   * @param {number} [options.agent.maxFreeSockets] Maximum number of sockets to leave open
-   * if keepAlive is true.
-   * @param {number} [options.agent.timeout] Socket timeout in milliseconds.
+   * @param {object} [options.agent] http.Agent/https.Agent object.
    * @param {object} [options.certificate] Certificate options for the request (HTTPS).
    * @param {string|Buffer} [options.certificate.ca] Override the trusted CA certificates.
    * @param {string|Buffer} [options.certificate.cert] Certificate chains in PEM format.
@@ -319,6 +286,7 @@ class WebReq {
    * @param {string} [options.certificate.passphrase] Shared passphrase for a private key and/or PFX.
    * @param {string|Buffer|Array} [options.certificate.pfx] PFX pr PKCS12 encoded private key and
    * certificate chain.
+   * @param {string} [options.proxy] Proxy to use for the request.
    * @param {function} [callback] Optional callback funtion.
    * @return {function|Promise} Returns a Promise which resolves to a Response object if no callback is provided.
    */

--- a/lib/webreq.js
+++ b/lib/webreq.js
@@ -5,7 +5,7 @@ const https = require('https');
 const url = require('url');
 
 const Response = require('./response');
-const { createRequestOptions, parseResponseBody, filename } = require('./utils');
+const { createRequestOptions, filename, isStream, parseResponseBody } = require('./utils');
 
 /**
  * Used to make HTTP/HTTPS requests.
@@ -72,8 +72,12 @@ class WebReq {
     opts.parse = opts.parse === undefined ? this.parse : opts.parse;
     opts.followRedirects = opts.followRedirects === undefined ? this.followRedirects : opts.followRedirects;
     opts.maxRedirects = opts.maxRedirects === undefined ? this.maxRedirects : opts.maxRedirects;
-
     opts.redirects = 0;
+
+    // Handle body options. Stringify if options is JSON object and not a stream.
+    if (opts.body && !isStream(opts.body) && typeof opts.body !== 'string') {
+      opts.body = JSON.stringify(opts.body);
+    }
 
     if (!callback) {
       return new Promise((resolve, reject) => {
@@ -362,11 +366,9 @@ function _request(uri, options, callback) {
   let parsedUrl = url.parse(uri);
   let requestOptions = createRequestOptions(parsedUrl, options)
   let proto = parsedUrl.protocol === 'http:' ? http : https;
-
   // Add agent if such was passed.
-  if (options.agent) {
-    let agent = new proto.Agent(options.agent);
-    requestOptions.agent = agent;
+  if (options.agent !== undefined) {
+    requestOptions.agent = options.agent !== false ? new proto.Agent(requestOptions) : false;
   }
 
   let req = proto.request(requestOptions, (res) => {
@@ -393,9 +395,11 @@ function _request(uri, options, callback) {
     callback(err);
   });
 
+  // Handle request body.
   if (options.body) {
     req.write(options.body);
   }
+
   req.end();
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webreq",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,14 +14,14 @@
       }
     },
     "@babel/generator": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.2.0.tgz",
-      "integrity": "sha512-BA75MVfRlFQG2EZgFYIwyT1r6xSkwfP2bdkY/kLZusEYWiJs4xCowab/alaEaT0wSvmVuXGqiefeBlP+7V1yKg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+      "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.2.0",
+        "@babel/types": "^7.4.4",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.11",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       }
@@ -47,12 +47,12 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-      "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.4.4"
       }
     },
     "@babel/highlight": {
@@ -67,64 +67,64 @@
       }
     },
     "@babel/parser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.2.0.tgz",
-      "integrity": "sha512-M74+GvK4hn1eejD9lZ7967qAwvqTZayQa3g10ag4s9uewgR7TKjeaT0YMyoq+gVfKYABiWZ4MQD701/t5e1Jhg==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+      "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
-      "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+      "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.1.2",
-        "@babel/types": "^7.1.2"
+        "@babel/parser": "^7.4.4",
+        "@babel/types": "^7.4.4"
       }
     },
     "@babel/traverse": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.6.tgz",
-      "integrity": "sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+      "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.1.6",
+        "@babel/generator": "^7.4.4",
         "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/parser": "^7.1.6",
-        "@babel/types": "^7.1.6",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/parser": "^7.4.5",
+        "@babel/types": "^7.4.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
     },
     "@babel/types": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.2.0.tgz",
-      "integrity": "sha512-b4v7dyfApuKDvmPb+O488UlGuR1WbwMXFsO/cyqMrnfvRAChZKJAYeeglWTjUO1b9UghKKgepAQM5tsvBJca6A==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+      "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.11",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -163,6 +163,12 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true
+    },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -170,6 +176,30 @@
       "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
+      }
+    },
+    "append-transform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+      "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+      "dev": true,
+      "requires": {
+        "default-require-extensions": "^2.0.0"
+      }
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-from": {
@@ -206,6 +236,24 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "caching-transform": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
+      "integrity": "sha512-Mtgcv3lh3U0zRii/6qVgQODdPA4G3zhG+jtbCWj39RXuUFTMzH0vcdMtaJS1jPowd+It2Pqr6y3NJMQqOqCE2w==",
+      "dev": true,
+      "requires": {
+        "hasha": "^3.0.0",
+        "make-dir": "^2.0.0",
+        "package-hash": "^3.0.0",
+        "write-file-atomic": "^2.4.2"
+      }
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
     "chai": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
@@ -221,9 +269,9 @@
       }
     },
     "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
@@ -236,6 +284,17 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
+    },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
     },
     "color-convert": {
       "version": "1.9.3",
@@ -258,11 +317,49 @@
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "cp-file": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-6.2.0.tgz",
+      "integrity": "sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^2.0.0",
+        "nested-error-stacks": "^2.0.0",
+        "pify": "^4.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "cross-spawn": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "which": "^1.2.9"
+      }
     },
     "debug": {
       "version": "3.1.0",
@@ -273,6 +370,12 @@
         "ms": "2.0.0"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -282,10 +385,49 @@
         "type-detect": "^4.0.0"
       }
     },
+    "default-require-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+      "dev": true,
+      "requires": {
+        "strip-bom": "^3.0.0"
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
     },
     "escape-string-regexp": {
@@ -294,11 +436,77 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
+    },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
+      }
+    },
+    "find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      }
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
+    "foreground-child": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+      "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^4",
+        "signal-exit": "^3.0.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -306,11 +514,26 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
     },
     "glob": {
       "version": "7.1.2",
@@ -327,9 +550,15 @@
       }
     },
     "globals": {
-      "version": "11.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
-      "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
     "growl": {
@@ -338,16 +567,57 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
+    "handlebars": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "dev": true,
+      "requires": {
+        "neo-async": "^2.6.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "hasha": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
+      "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+      "dev": true,
+      "requires": {
+        "is-stream": "^1.0.1"
+      }
+    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "inflight": {
@@ -366,31 +636,145 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
+    "invert-kv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+      "dev": true
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
-    "istanbul-lib-coverage": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-      "integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "istanbul-lib-instrument": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.0.0.tgz",
-      "integrity": "sha512-eQY9vN9elYjdgN9Iv6NS/00bptm02EBBk70lRMaVjeA6QYocQgenVrSgC28TJurdnZa80AGO3ASdFN+w/njGiQ==",
+    "istanbul-lib-coverage": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+      "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+      "dev": true
+    },
+    "istanbul-lib-hook": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
+      "integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
       "dev": true,
       "requires": {
-        "@babel/generator": "^7.0.0",
-        "@babel/parser": "^7.0.0",
-        "@babel/template": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "istanbul-lib-coverage": "^2.0.1",
-        "semver": "^5.5.0"
+        "append-transform": "^1.0.0"
+      }
+    },
+    "istanbul-lib-instrument": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+      "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.4.0",
+        "@babel/parser": "^7.4.3",
+        "@babel/template": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "istanbul-lib-coverage": "^2.0.5",
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+          "integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+      "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+      "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "rimraf": "^2.6.3",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.1.2"
       }
     },
     "js-tokens": {
@@ -399,10 +783,26 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
     "just-extend": {
@@ -411,16 +811,124 @@
       "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
       "dev": true
     },
+    "lcid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^2.0.0"
+      }
+    },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
     "lolex": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.1.0.tgz",
       "integrity": "sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "requires": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      }
+    },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
+    "mem": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "dev": true,
+      "requires": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
+      }
+    },
+    "merge-source-map": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+      "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
     "minimatch": {
@@ -472,6 +980,24 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "neo-async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "dev": true
+    },
+    "nested-error-stacks": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
+      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
     "nise": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.10.tgz",
@@ -493,289 +1019,64 @@
         }
       }
     },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
     "nyc": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.1.0.tgz",
-      "integrity": "sha512-3GyY6TpQ58z9Frpv4GMExE1SV2tAgYqC7HSy2omEhNiCT3mhT9NyiOvIE8zkbuJVFzmvvNTnE4h/7/wQae7xLg==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-14.1.1.tgz",
+      "integrity": "sha512-OI0vm6ZGUnoGZv/tLdZ2esSVzDwUC88SNs+6JoSOMVxA+gKMB8Tk7jBwgemLx4O40lhhvZCVw1C+OYLOBOPXWw==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
-        "arrify": "^1.0.1",
-        "caching-transform": "^2.0.0",
+        "caching-transform": "^3.0.2",
         "convert-source-map": "^1.6.0",
-        "debug-log": "^1.0.1",
-        "find-cache-dir": "^2.0.0",
+        "cp-file": "^6.2.0",
+        "find-cache-dir": "^2.1.0",
         "find-up": "^3.0.0",
         "foreground-child": "^1.5.6",
         "glob": "^7.1.3",
-        "istanbul-lib-coverage": "^2.0.1",
-        "istanbul-lib-hook": "^2.0.1",
-        "istanbul-lib-instrument": "^3.0.0",
-        "istanbul-lib-report": "^2.0.2",
-        "istanbul-lib-source-maps": "^2.0.1",
-        "istanbul-reports": "^2.0.1",
-        "make-dir": "^1.3.0",
+        "istanbul-lib-coverage": "^2.0.5",
+        "istanbul-lib-hook": "^2.0.7",
+        "istanbul-lib-instrument": "^3.3.0",
+        "istanbul-lib-report": "^2.0.8",
+        "istanbul-lib-source-maps": "^3.0.6",
+        "istanbul-reports": "^2.2.4",
+        "js-yaml": "^3.13.1",
+        "make-dir": "^2.1.0",
         "merge-source-map": "^1.1.0",
         "resolve-from": "^4.0.0",
-        "rimraf": "^2.6.2",
+        "rimraf": "^2.6.3",
         "signal-exit": "^3.0.2",
         "spawn-wrap": "^1.4.2",
-        "test-exclude": "^5.0.0",
+        "test-exclude": "^5.2.3",
         "uuid": "^3.3.2",
-        "yargs": "11.1.0",
-        "yargs-parser": "^9.0.2"
+        "yargs": "^13.2.2",
+        "yargs-parser": "^13.0.0"
       },
       "dependencies": {
-        "align-text": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2",
-            "longest": "^1.0.1",
-            "repeat-string": "^1.5.2"
-          }
-        },
-        "amdefine": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "append-transform": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "default-require-extensions": "^2.0.0"
-          }
-        },
-        "archy": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "async": {
-          "version": "1.5.2",
-          "bundled": true,
-          "dev": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "caching-transform": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "make-dir": "^1.0.0",
-            "md5-hex": "^2.0.0",
-            "package-hash": "^2.0.0",
-            "write-file-atomic": "^2.0.0"
-          }
-        },
-        "camelcase": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "center-align": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "^0.1.3",
-            "lazy-cache": "^1.0.3"
-          }
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
-            "wordwrap": "0.0.2"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "commondir": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "convert-source-map": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.1"
-          }
-        },
-        "cross-spawn": {
-          "version": "4.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "debug-log": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "default-require-extensions": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "strip-bom": "^3.0.0"
-          }
-        },
-        "error-ex": {
-          "version": "1.3.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-arrayish": "^0.2.1"
-          }
-        },
-        "es6-error": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "execa": {
-          "version": "0.7.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          },
-          "dependencies": {
-            "cross-spawn": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              }
-            }
-          }
-        },
-        "find-cache-dir": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "commondir": "^1.0.1",
-            "make-dir": "^1.0.0",
-            "pkg-dir": "^3.0.0"
-          }
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "foreground-child": {
-          "version": "1.5.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^4",
-            "signal-exit": "^3.0.0"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "get-caller-file": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "glob": {
-          "version": "7.1.3",
-          "bundled": true,
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -784,850 +1085,6 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "handlebars": {
-          "version": "4.0.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "async": "^1.4.0",
-            "optimist": "^0.6.1",
-            "source-map": "^0.4.4",
-            "uglify-js": "^2.6"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.4.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
-            }
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "hosted-git-info": {
-          "version": "2.7.1",
-          "bundled": true,
-          "dev": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-buffer": {
-          "version": "1.1.6",
-          "bundled": true,
-          "dev": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "builtin-modules": "^1.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isexe": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "istanbul-lib-coverage": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "istanbul-lib-hook": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "append-transform": "^1.0.0"
-          }
-        },
-        "istanbul-lib-report": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "istanbul-lib-coverage": "^2.0.1",
-            "make-dir": "^1.3.0",
-            "supports-color": "^5.4.0"
-          }
-        },
-        "istanbul-lib-source-maps": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "debug": "^3.1.0",
-            "istanbul-lib-coverage": "^2.0.1",
-            "make-dir": "^1.3.0",
-            "rimraf": "^2.6.2",
-            "source-map": "^0.6.1"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "istanbul-reports": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "handlebars": "^4.0.11"
-          }
-        },
-        "json-parse-better-errors": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "lodash.flattendeep": {
-          "version": "4.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "longest": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "4.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "make-dir": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "md5-hex": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "md5-o-matic": "^0.1.1"
-          }
-        },
-        "md5-o-matic": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "mem": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "merge-source-map": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "source-map": "^0.6.1"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "mimic-fn": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.10",
-          "bundled": true,
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "normalize-package-data": {
-          "version": "2.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          }
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "~0.0.1",
-            "wordwrap": "~0.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "p-limit": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "package-hash": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "lodash.flattendeep": "^4.4.0",
-            "md5-hex": "^2.0.0",
-            "release-zalgo": "^1.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-type": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "pify": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "find-up": "^3.0.0"
-          }
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "find-up": "^3.0.0",
-            "read-pkg": "^3.0.0"
-          }
-        },
-        "release-zalgo": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "es6-error": "^4.0.1"
-          }
-        },
-        "repeat-string": {
-          "version": "1.6.1",
-          "bundled": true,
-          "dev": true
-        },
-        "require-directory": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "resolve-from": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "right-align": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "^0.1.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true,
-          "dev": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "spawn-wrap": {
-          "version": "1.4.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "foreground-child": "^1.5.6",
-            "mkdirp": "^0.5.0",
-            "os-homedir": "^1.0.1",
-            "rimraf": "^2.6.2",
-            "signal-exit": "^3.0.2",
-            "which": "^1.3.0"
-          }
-        },
-        "spdx-correct": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-expression-parse": "^3.0.0",
-            "spdx-license-ids": "^3.0.0"
-          }
-        },
-        "spdx-exceptions": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "spdx-expression-parse": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-exceptions": "^2.1.0",
-            "spdx-license-ids": "^3.0.0"
-          }
-        },
-        "spdx-license-ids": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "strip-eof": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "test-exclude": {
-          "version": "5.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arrify": "^1.0.1",
-            "minimatch": "^3.0.4",
-            "read-pkg-up": "^4.0.0",
-            "require-main-filename": "^1.0.1"
-          }
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
-          },
-          "dependencies": {
-            "yargs": {
-              "version": "3.10.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "camelcase": "^1.0.2",
-                "cliui": "^2.1.0",
-                "decamelize": "^1.0.0",
-                "window-size": "0.1.0"
-              }
-            }
-          }
-        },
-        "uglify-to-browserify": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "bundled": true,
-          "dev": true
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-correct": "^3.0.0",
-            "spdx-expression-parse": "^3.0.0"
-          }
-        },
-        "which": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            }
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "write-file-atomic": {
-          "version": "2.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "yargs": {
-          "version": "11.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
-          },
-          "dependencies": {
-            "cliui": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
-              }
-            },
-            "find-up": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "locate-path": "^2.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
-              }
-            },
-            "p-limit": {
-              "version": "1.3.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-try": "^1.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "p-limit": "^1.1.0"
-              }
-            },
-            "p-try": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "9.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true
-            }
           }
         }
       }
@@ -1641,10 +1098,119 @@
         "wrappy": "1"
       }
     },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-locale": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+      "dev": true,
+      "requires": {
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
+      }
+    },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "package-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
+      "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.15",
+        "hasha": "^3.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      }
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-to-regexp": {
@@ -1656,16 +1222,179 @@
         "isarray": "0.0.1"
       }
     },
+    "path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true
+    },
+    "pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0"
+      }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+      "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0",
+        "read-pkg": "^3.0.0"
+      }
+    },
+    "release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "dev": true,
+      "requires": {
+        "es6-error": "^4.0.1"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
     "sinon": {
@@ -1700,6 +1429,90 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
+    "spawn-wrap": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+      "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
+      "dev": true,
+      "requires": {
+        "foreground-child": "^1.5.6",
+        "mkdirp": "^0.5.0",
+        "os-homedir": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "signal-exit": "^3.0.2",
+        "which": "^1.3.0"
+      }
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^4.1.0"
+      }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
     "supports-color": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
@@ -1707,6 +1520,34 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "test-exclude": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+      "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3",
+        "minimatch": "^3.0.4",
+        "read-pkg-up": "^4.0.0",
+        "require-main-filename": "^2.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "to-fast-properties": {
@@ -1727,11 +1568,138 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
+    "uglify-js": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
+      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "commander": "~2.20.0",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true,
+          "optional": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write-file-atomic": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
+      "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
+      "dev": true,
+      "requires": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "os-locale": "^3.1.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.0"
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,38 +129,53 @@
       }
     },
     "@sinonjs/commons": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
-      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
+      "integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
     },
     "@sinonjs/formatio": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
-      "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/samsam": "^2 || ^3"
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.1.1.tgz",
-      "integrity": "sha512-ILlwvQUwAiaVBzr3qz8oT1moM7AIUHqUc2UmEjQcH9lLe+E+BZPwUMuc9FFojMswRK4r96x5zDTTrowMLw/vuA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.0.2",
+        "@sinonjs/commons": "^1.3.0",
         "array-from": "^2.1.1",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "@sinonjs/text-encoding": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
       "dev": true
     },
     "ansi-regex": {
@@ -296,6 +311,12 @@
         "wrap-ansi": "^5.1.0"
       }
     },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -309,12 +330,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "commander": {
-      "version": "2.15.1",
-      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
     "commondir": {
@@ -362,12 +377,12 @@
       }
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "decamelize": {
@@ -392,6 +407,15 @@
       "dev": true,
       "requires": {
         "strip-bom": "^3.0.0"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
       }
     },
     "diff": {
@@ -422,6 +446,31 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "es6-error": {
@@ -498,6 +547,15 @@
         "locate-path": "^3.0.0"
       }
     },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      }
+    },
     "foreground-child": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
@@ -512,6 +570,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "get-caller-file": {
@@ -536,9 +600,9 @@
       }
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -587,10 +651,25 @@
         }
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "hasha": {
@@ -603,9 +682,9 @@
       }
     },
     "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
     "hosted-git-info": {
@@ -648,17 +727,53 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-buffer": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
     },
     "isarray": {
       "version": "0.0.1",
@@ -862,10 +977,19 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      }
+    },
     "lolex": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.1.0.tgz",
-      "integrity": "sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
       "dev": true
     },
     "lru-cache": {
@@ -956,28 +1080,165 @@
       }
     },
     "mocha": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.0.tgz",
+      "integrity": "sha512-qwfFgY+7EKAAUAdv7VYMZQknI7YJSGesxHyhn6qD52DV8UcSZs5XwCifcZGMVIE4a5fbmhvbotxC0DLQ0oKohQ==",
       "dev": true,
       "requires": {
+        "ansi-colors": "3.2.3",
         "browser-stdout": "1.3.1",
-        "commander": "2.15.1",
-        "debug": "3.1.0",
+        "debug": "3.2.6",
         "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
         "growl": "1.10.5",
-        "he": "1.1.1",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "2.2.0",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "supports-color": "5.4.0"
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.5",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.2.2",
+        "yargs-parser": "13.0.0",
+        "yargs-unparser": "1.5.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
+          }
+        },
+        "yargs": {
+          "version": "13.2.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
+          "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "os-locale": "^3.1.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
+          "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
     },
     "neo-async": {
@@ -999,24 +1260,26 @@
       "dev": true
     },
     "nise": {
-      "version": "1.4.10",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.10.tgz",
-      "integrity": "sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
+      "integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/formatio": "^3.2.1",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
-        "lolex": "^2.3.2",
+        "lolex": "^4.1.0",
         "path-to-regexp": "^1.7.0"
-      },
-      "dependencies": {
-        "lolex": {
-          "version": "2.7.5",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
-          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
-          "dev": true
-        }
+      }
+    },
+    "node-environment-flags": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+      "dev": true,
+      "requires": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
       }
     },
     "normalize-package-data": {
@@ -1039,6 +1302,12 @@
       "requires": {
         "path-key": "^2.0.0"
       }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "nyc": {
       "version": "14.1.1",
@@ -1087,6 +1356,34 @@
             "path-is-absolute": "^1.0.0"
           }
         }
+      }
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "once": {
@@ -1398,17 +1695,17 @@
       "dev": true
     },
     "sinon": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.4.tgz",
-      "integrity": "sha512-FGlcfrkiBRfaEIKRw8s/9mk4nP4AMGswvKFixLo+AzsOhskjaBCHAHGLMd8pCJpQGS+9ZI71px6qoQUyvADeyA==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.4.2.tgz",
+      "integrity": "sha512-pY5RY99DKelU3pjNxcWo6XqeB1S118GBcVIIdDi6V+h6hevn1izcg2xv1hTHW/sViRXU7sUOxt4wTUJ3gsW2CQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.3.0",
-        "@sinonjs/formatio": "^3.1.0",
-        "@sinonjs/samsam": "^3.1.1",
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.3",
         "diff": "^3.5.0",
-        "lolex": "^3.1.0",
-        "nise": "^1.4.10",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.2",
         "supports-color": "^5.5.0"
       },
       "dependencies": {
@@ -1511,6 +1808,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
     "supports-color": {
@@ -1626,6 +1929,42 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -1699,6 +2038,144 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
+      "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.11",
+        "yargs": "^12.0.5"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
+          }
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webreq",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Small and simple module for handling HTTP/HTTPS requests.",
   "main": "./lib/webreq.js",
   "scripts": {
@@ -25,10 +25,11 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "^5.2.0",
-    "nyc": "^13.1.0",
+    "nyc": "^14.1.1",
     "sinon": "^7.2.4"
   },
   "engines": {
     "node": ">=8.5.0"
-  }
+  },
+  "types": "lib/types/webreq.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,5 @@
   },
   "engines": {
     "node": ">=8.5.0"
-  },
-  "types": "lib/webreq.d.ts"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "homepage": "https://github.com/RedeployAB/webreq#readme",
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^5.2.0",
+    "mocha": "^6.2.0",
     "nyc": "^14.1.1",
-    "sinon": "^7.2.4"
+    "sinon": "^7.4.2"
   },
   "engines": {
     "node": ">=8.5.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webreq",
   "version": "0.5.0",
   "description": "Small and simple module for handling HTTP/HTTPS requests.",
-  "main": "./lib/webreq.js",
+  "main": "lib/webreq.js",
   "scripts": {
     "test": "nyc mocha --timeout 10000",
     "report-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov"
@@ -31,5 +31,5 @@
   "engines": {
     "node": ">=8.5.0"
   },
-  "types": "lib/types/webreq.d.ts"
+  "types": "lib/webreq.d.ts"
 }

--- a/test/mockdata/test.txt
+++ b/test/mockdata/test.txt
@@ -1,0 +1,1 @@
+Test data

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -8,7 +8,7 @@ describe('request-utils', () => {
 
   describe('createRequestOptions()', () => {
 
-    it('should parse hostname, port, path and headers (HTTPS default to 443, default to GET)', (done) => {
+    it('should parse hostname, port, path and headers (HTTPS default to 443, default to GET)', () => {
 
       let parsedUrl = url.parse('https://codecloudandrants.io');
       let requestOptions = createRequestOptions(parsedUrl);
@@ -18,11 +18,9 @@ describe('request-utils', () => {
       expect(requestOptions.path).to.equal('/');
       expect(requestOptions.method).to.equal('GET');
       expect(requestOptions.headers).to.be.undefined;
-
-      done();
     });
 
-    it('should parse should parse hostname, port, path, method and headers (with port in url)', (done) => {
+    it('should parse should parse hostname, port, path, method and headers (with port in url)', () => {
 
       let options = { method: 'POST', headers: { 'Content-Type': 'application/json' } };
       let parsedUrl = url.parse('https://codecloudandrants.io:8443/a-path?istrue=true');
@@ -33,11 +31,9 @@ describe('request-utils', () => {
       expect(requestOptions.path).to.equal('/a-path?istrue=true');
       expect(requestOptions.method).to.equal('POST');
       expect(requestOptions.headers).to.be.an('Object');
-
-      done();
     });
 
-    it('should parse hostname, port, path and headers (HTTP default to 80)', (done) => {
+    it('should parse hostname, port, path and headers (HTTP default to 80)', () => {
 
       let parsedUrl = url.parse('http://codecloudandrants.io');
       let requestOptions = createRequestOptions(parsedUrl);
@@ -47,11 +43,9 @@ describe('request-utils', () => {
       expect(requestOptions.path).to.equal('/');
       expect(requestOptions.method).to.equal('GET');
       expect(requestOptions.headers).to.be.undefined;
-
-      done();
     });
 
-    it('should parse hostname, port, path and headers (with port in URL)', (done) => {
+    it('should parse hostname, port, path and headers (with port in URL)', () => {
 
       let parsedUrl = url.parse('http://codecloudandrants.io:8080');
       let requestOptions = createRequestOptions(parsedUrl);
@@ -61,14 +55,27 @@ describe('request-utils', () => {
       expect(requestOptions.path).to.equal('/');
       expect(requestOptions.method).to.equal('GET');
       expect(requestOptions.headers).to.be.undefined;
+    });
 
-      done();
+    it('should add additional ssl/cert options if protocol is https and they are provided in options.certificate', () => {
+
+      let options = { method: 'POST', headers: { 'Content-Type': 'application/json' }, certificate: { ca: 'pathToCert' }};
+      let parsedUrl = url.parse('https://codecloudandrants.io');
+
+      let requestOptions = createRequestOptions(parsedUrl, options);
+
+      expect(requestOptions.hostname).to.equal('codecloudandrants.io');
+      expect(requestOptions.port).to.equal(443);
+      expect(requestOptions.path).to.equal('/');
+      expect(requestOptions.method).to.equal('POST');
+      expect(requestOptions.headers).to.be.an('Object');
+      expect(requestOptions.ca).to.equal('pathToCert');
     });
   });
 
   describe('parseResponseBody()', () => {
 
-    it('should try to parse the response as JSON (return JSON object) if no Content-Type is present', (done) => {
+    it('should try to parse the response as JSON (return JSON object) if no Content-Type is present', () => {
       let headers = {};
       let str = '{"data":"some data"}';
       let buf = Buffer.from(str, 'utf8');
@@ -76,11 +83,9 @@ describe('request-utils', () => {
 
       expect(parsedBody).to.be.an('Object');
       expect(parsedBody.data).equal('some data');
-
-      done();
     });
 
-    it('should try to parse the response as JSON (return string) if no Content-Type is present', (done) => {
+    it('should try to parse the response as JSON (return string) if no Content-Type is present', () => {
       let headers = {};
       let str = 'some data';
       let buf = Buffer.from(str, 'utf8');
@@ -88,11 +93,9 @@ describe('request-utils', () => {
 
       expect(parsedBody).to.be.a('string');
       expect(parsedBody).to.equal('some data')
-
-      done();
     });
 
-    it('should try to parse the response as JSON (return JSON object) if Content-Type (application/json) is present', (done) => {
+    it('should try to parse the response as JSON (return JSON object) if Content-Type (application/json) is present', () => {
       let headers = { 'content-type': 'application/json' };
       let str = '{"data":"some data"}';
       let buf = Buffer.from(str, 'utf8');
@@ -100,11 +103,9 @@ describe('request-utils', () => {
 
       expect(parsedBody).to.be.an('Object');
       expect(parsedBody.data).equal('some data');
-
-      done();
     });
 
-    it('should try to parse the response as plain text (return string) if Content-Type (text/html) is present', (done) => {
+    it('should try to parse the response as plain text (return string) if Content-Type (text/html) is present', () => {
       let headers = { 'content-type': 'text/html' };
       let str = 'some data';
       let buf = Buffer.from(str, 'utf8');
@@ -112,11 +113,9 @@ describe('request-utils', () => {
 
       expect(parsedBody).to.be.a('string');
       expect(parsedBody).to.equal('some data')
-
-      done();
     });
 
-    it('should try to parse the response as plain text (return string) if Content-Type (other) is present', (done) => {
+    it('should try to parse the response as plain text (return string) if Content-Type (other) is present', () => {
       let headers = { 'content-type': 'text/plain' };
       let str = 'some data';
       let buf = Buffer.from(str, 'utf8');
@@ -124,26 +123,21 @@ describe('request-utils', () => {
 
       expect(parsedBody).to.be.a('string');
       expect(parsedBody).to.equal('some data')
-
-      done();
     });
   });
 
   describe('isStream()', () => {
 
-    it('should return true if passed in object is a stream', (done) => {
+    it('should return true if passed in object is a stream', () => {
       let rs = fs.createReadStream(__dirname + '/mockfile/read.txt');
       expect(isStream(rs)).to.be.true;
-      done();
     });
 
-    it('shoul return false if passed in object is not a stream', (done) => {
+    it('shoul return false if passed in object is not a stream', () => {
       let obj1 = {}, obj2 = 'string';
 
       expect(isStream(obj1)).to.be.false;
       expect(isStream(obj2)).to.be.false;
-
-      done();
     });
   });
 });

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -8,25 +8,25 @@ describe('request-utils', () => {
 
   describe('createRequestOptions()', () => {
 
-    it('should parse hostname, port, path and headers (HTTPS default to 443, default to GET)', () => {
+    it('should parse host, port, path and headers (HTTPS default to 443, default to GET)', () => {
 
-      let parsedUrl = url.parse('https://codecloudandrants.io');
+      let parsedUrl = url.parse('https://someurl');
       let requestOptions = createRequestOptions(parsedUrl);
 
-      expect(requestOptions.hostname).to.equal('codecloudandrants.io');
+      expect(requestOptions.host).to.equal('someurl');
       expect(requestOptions.port).to.equal(443);
       expect(requestOptions.path).to.equal('/');
       expect(requestOptions.method).to.equal('GET');
       expect(requestOptions.headers).to.be.undefined;
     });
 
-    it('should parse should parse hostname, port, path, method and headers (with port in url)', () => {
+    it('should parse should parse host, port, path, method and headers (with port in url)', () => {
 
       let options = { method: 'POST', headers: { 'Content-Type': 'application/json' } };
-      let parsedUrl = url.parse('https://codecloudandrants.io:8443/a-path?istrue=true');
+      let parsedUrl = url.parse('https://someurl:8443/a-path?istrue=true');
       let requestOptions = createRequestOptions(parsedUrl, options);
 
-      expect(requestOptions.hostname).to.equal('codecloudandrants.io');
+      expect(requestOptions.host).to.equal('someurl');
       expect(requestOptions.port).to.equal(8443);
       expect(requestOptions.path).to.equal('/a-path?istrue=true');
       expect(requestOptions.method).to.equal('POST');
@@ -36,10 +36,10 @@ describe('request-utils', () => {
     it('should set Content-Length header if a body is in the options without Content-Length', () => {
 
       let options = { method: 'POST', body: '{"data":"somedata"}' };
-      let parsedUrl = url.parse('https://codecloudandrants.io:8443/a-path?istrue=true');
+      let parsedUrl = url.parse('https://someurl:8443/a-path?istrue=true');
       let requestOptions = createRequestOptions(parsedUrl, options);
 
-      expect(requestOptions.hostname).to.equal('codecloudandrants.io');
+      expect(requestOptions.host).to.equal('someurl');
       expect(requestOptions.port).to.equal(8443);
       expect(requestOptions.path).to.equal('/a-path?istrue=true');
       expect(requestOptions.method).to.equal('POST');
@@ -49,34 +49,34 @@ describe('request-utils', () => {
     it('should set Content-Length header if a body is in the options with Content-Length', () => {
 
       let options = { method: 'POST', body: '{"data":"somedata"}', headers: {'Content-Length': 19 } };
-      let parsedUrl = url.parse('https://codecloudandrants.io:8443/a-path?istrue=true');
+      let parsedUrl = url.parse('https://someurl:8443/a-path?istrue=true');
       let requestOptions = createRequestOptions(parsedUrl, options);
 
-      expect(requestOptions.hostname).to.equal('codecloudandrants.io');
+      expect(requestOptions.host).to.equal('someurl');
       expect(requestOptions.port).to.equal(8443);
       expect(requestOptions.path).to.equal('/a-path?istrue=true');
       expect(requestOptions.method).to.equal('POST');
       expect(requestOptions.headers).to.be.an('Object');
     });
 
-    it('should parse hostname, port, path and headers (HTTP default to 80)', () => {
+    it('should parse host, port, path and headers (HTTP default to 80)', () => {
 
-      let parsedUrl = url.parse('http://codecloudandrants.io');
+      let parsedUrl = url.parse('http://someurl');
       let requestOptions = createRequestOptions(parsedUrl);
 
-      expect(requestOptions.hostname).to.equal('codecloudandrants.io');
+      expect(requestOptions.host).to.equal('someurl');
       expect(requestOptions.port).to.equal(80);
       expect(requestOptions.path).to.equal('/');
       expect(requestOptions.method).to.equal('GET');
       expect(requestOptions.headers).to.be.undefined;
     });
 
-    it('should parse hostname, port, path and headers (with port in URL)', () => {
+    it('should parse host, port, path and headers (with port in URL)', () => {
 
-      let parsedUrl = url.parse('http://codecloudandrants.io:8080');
+      let parsedUrl = url.parse('http://someurl:8080');
       let requestOptions = createRequestOptions(parsedUrl);
 
-      expect(requestOptions.hostname).to.equal('codecloudandrants.io');
+      expect(requestOptions.host).to.equal('someurl');
       expect(requestOptions.port).to.equal(8080);
       expect(requestOptions.path).to.equal('/');
       expect(requestOptions.method).to.equal('GET');
@@ -86,16 +86,27 @@ describe('request-utils', () => {
     it('should add additional ssl/cert options if protocol is https and they are provided in options.certificate', () => {
 
       let options = { method: 'POST', headers: { 'Content-Type': 'application/json' }, certificate: { ca: 'pathToCert' }};
-      let parsedUrl = url.parse('https://codecloudandrants.io');
+      let parsedUrl = url.parse('https://someurl');
 
       let requestOptions = createRequestOptions(parsedUrl, options);
 
-      expect(requestOptions.hostname).to.equal('codecloudandrants.io');
+      expect(requestOptions.host).to.equal('someurl');
       expect(requestOptions.port).to.equal(443);
       expect(requestOptions.path).to.equal('/');
       expect(requestOptions.method).to.equal('POST');
       expect(requestOptions.headers).to.be.an('Object');
       expect(requestOptions.ca).to.equal('pathToCert');
+    });
+
+    it('should handle proxy parameter', () => {
+      let options = { method: 'GET', header: { 'Content-Type': 'application/json' }, proxy: 'https://proxy.local:8080' };
+      let parsedUrl = url.parse('https://someurl');
+
+      let requestOptions = createRequestOptions(parsedUrl, options);
+
+      expect(requestOptions.host).to.equal('proxy.local');
+      expect(requestOptions.port).to.equal('8080');
+      expect(requestOptions.headers['Host']).to.equal('https://someurl');
     });
   });
 

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -33,6 +33,32 @@ describe('request-utils', () => {
       expect(requestOptions.headers).to.be.an('Object');
     });
 
+    it('should set Content-Length header if a body is in the options without Content-Length', () => {
+
+      let options = { method: 'POST', body: '{"data":"somedata"}' };
+      let parsedUrl = url.parse('https://codecloudandrants.io:8443/a-path?istrue=true');
+      let requestOptions = createRequestOptions(parsedUrl, options);
+
+      expect(requestOptions.hostname).to.equal('codecloudandrants.io');
+      expect(requestOptions.port).to.equal(8443);
+      expect(requestOptions.path).to.equal('/a-path?istrue=true');
+      expect(requestOptions.method).to.equal('POST');
+      expect(requestOptions.headers).to.be.an('Object');
+    });
+
+    it('should set Content-Length header if a body is in the options with Content-Length', () => {
+
+      let options = { method: 'POST', body: '{"data":"somedata"}', headers: {'Content-Length': 19 } };
+      let parsedUrl = url.parse('https://codecloudandrants.io:8443/a-path?istrue=true');
+      let requestOptions = createRequestOptions(parsedUrl, options);
+
+      expect(requestOptions.hostname).to.equal('codecloudandrants.io');
+      expect(requestOptions.port).to.equal(8443);
+      expect(requestOptions.path).to.equal('/a-path?istrue=true');
+      expect(requestOptions.method).to.equal('POST');
+      expect(requestOptions.headers).to.be.an('Object');
+    });
+
     it('should parse hostname, port, path and headers (HTTP default to 80)', () => {
 
       let parsedUrl = url.parse('http://codecloudandrants.io');

--- a/test/webreq.spec.js
+++ b/test/webreq.spec.js
@@ -129,6 +129,27 @@ describe('webreq', () => {
       });
     });
 
+    it('should handle a GET request with modified agent settings (false) (promise)', () => {
+      let mockRes = { data: "data" };
+
+      let response = new PassThrough();
+      response.headers = { 'content-type': 'application/json' }
+      response.statusCode = 200;
+
+      response.write(JSON.stringify(mockRes));
+      response.end();
+
+      let request = new PassThrough();
+
+      this.request.callsArgWith(1, response).returns(request);
+
+      let options = { agent: false };
+
+      return webreq.request('https://someurl.not', options).then(res => {
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json' }, body: { data: "data" }});
+      });
+    });
+
     it('should handle a GET request and parse the results (callback)', (done) => {
       let mockRes = { data: "data" };
       let response = new PassThrough();

--- a/test/webreq.spec.js
+++ b/test/webreq.spec.js
@@ -38,7 +38,26 @@ describe('webreq', () => {
       this.request.callsArgWith(1, response).returns(request);
 
       return webreq.request('https://someurl.not').then(res => {
-        expect(res).to.eql({ data: "data" });
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json' }, body: { data: "data" }});
+      });
+    });
+
+    it('should handle a GET request and parse the results (promise)', () => {
+      let mockRes = { data: "data" };
+
+      let response = new PassThrough();
+      response.headers = { 'content-type': 'application/json' }
+      response.statusCode = 200;
+
+      response.write(JSON.stringify(mockRes));
+      response.end();
+
+      let request = new PassThrough();
+
+      this.request.callsArgWith(1, response).returns(request);
+
+      return webreq.request('https://someurl.not').then(res => {
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json' }, body: { data: "data" }});
       });
     });
 
@@ -58,7 +77,7 @@ describe('webreq', () => {
       this.request.callsArgWith(1, response).returns(request);
 
       return webreq.request('https://someurl.not', { followRedirects: true, maxRedirects: 3 }).then(res => {
-        expect(res).to.eql({ data: "data" });
+        expect(res).to.eql({ statusCode: 302, headers: { 'content-type': 'application/json', 'location': 'https://someurl.not/redirect' }, body: { data: "data" }});
       });
     });
 
@@ -78,7 +97,7 @@ describe('webreq', () => {
       this.request.callsArgWith(1, response).returns(request);
 
       return webreq.request('https://someurl.not', { followRedirects: true, maxRedirects: 3 }).then(res => {
-        expect(res).to.eql({ data: "data" });
+        expect(res).to.eql({ statusCode: 302, headers: { 'content-type': 'application/json' }, body: { data: "data" }});
       });
     });
 
@@ -106,7 +125,7 @@ describe('webreq', () => {
       };
 
       return webreq.request('https://someurl.not', options).then(res => {
-        expect(res).to.eql({ data: "data" });
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json' }, body: { data: "data" }});
       });
     });
 
@@ -124,7 +143,7 @@ describe('webreq', () => {
       this.request.callsArgWith(1, response).returns(request);
 
       webreq.request('https://someurl.not', (err, res) => {
-        expect(res).to.eql({ data: "data" });
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json' }, body: { data: "data" }});
         done();
       });
     });
@@ -143,7 +162,7 @@ describe('webreq', () => {
       this.request.callsArgWith(1, response).returns(request);
 
       webreq.request('https://someurl.not', { method: 'GET' }, (err, res) => {
-        expect(res).to.eql({ data: "data" });
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json' }, body: { data: "data" }});
         done();
       });
     });
@@ -152,7 +171,7 @@ describe('webreq', () => {
       let mockRes = '[{"some":"data"';
       let response = new PassThrough();
       response.headers = { 'content-type': 'application/json' }
-      response.statusCode = 200;
+      response.statusCode = 400;
 
       response.write(mockRes);
       response.end();
@@ -162,7 +181,7 @@ describe('webreq', () => {
       this.request.callsArgWith(1, response).returns(request);
 
       webreq.request('https://someurl.not', { method: 'GET' }, (err, res) => {
-        expect(res).to.equal('Malformed JSON.');
+        expect(res).to.eql({ statusCode: 400, headers: { 'content-type': 'application/json' },  body: 'Malformed JSON.' });
         done();
       });
     });
@@ -181,7 +200,7 @@ describe('webreq', () => {
       this.request.callsArgWith(1, response).returns(request);
 
       webreq.request('https://someurl.not', { method: 'GET', parse: false }, (err, res) => {
-        expect(res).to.eql('{"data":"data"}');
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json' }, body: '{"data":"data"}'});
         done();
       });
     });
@@ -199,7 +218,7 @@ describe('webreq', () => {
 
       this.request.callsArgWith(1, response).returns(request);
 
-      webreq.request('https://someurl.not', { method: 'GET', bodyOnly: false }, (err, res) => {
+      webreq.request('https://someurl.not', { method: 'GET' }, (err, res) => {
         expect(res).to.eql({ headers: { 'content-type': 'application/json' }, statusCode: 200, body: mockRes });
         done();
       });
@@ -221,7 +240,7 @@ describe('webreq', () => {
       let mockRes = { data: "data" };
 
       let response = new PassThrough();
-      response.headers = { 'content-type': 'application/json' }
+      response.headers = { 'content-type': 'application/json' };
       response.statusCode = 200;
 
       response.write(JSON.stringify(mockRes));
@@ -232,7 +251,7 @@ describe('webreq', () => {
       this.request.callsArgWith(1, response).returns(request);
 
       return webreq.get('https://someurl.not').then(res => {
-        expect(res).to.eql({ data: "data" });
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json' }, body: { data: "data" }});
       });
     });
 
@@ -250,7 +269,7 @@ describe('webreq', () => {
       this.request.callsArgWith(1, response).returns(request);
 
       webreq.get('https://someurl.not', (err, res) => {
-        expect(res).to.eql({ data: "data" });
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json' },  body: { data: "data" }});
         done();
       });
     });
@@ -339,7 +358,7 @@ describe('webreq', () => {
       this.request.callsArgWith(1, response).returns(request);
 
       webreq.post('https://someurl.not/id/1').then(res => {
-        expect(res).to.eql({ data: "data" });
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json' }, body: { data: "data" }});
         done();
       });
     });
@@ -359,7 +378,7 @@ describe('webreq', () => {
       this.request.callsArgWith(1, response).returns(request);
 
       webreq.post('https://someurl.not', (err, res) => {
-        expect(res).to.eql({ data: "data" });
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json' }, body: { data: "data" }});
         done();
       });
     });
@@ -420,7 +439,7 @@ describe('webreq', () => {
       this.request.callsArgWith(1, response).returns(request);
 
       webreq.put('https://someurl.not/id/1').then(res => {
-        expect(res).to.eql({ data: "data" });
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json' }, body: { data: "data" }});
         done();
       });
     });
@@ -440,7 +459,7 @@ describe('webreq', () => {
       this.request.callsArgWith(1, response).returns(request);
 
       webreq.put('https://someurl.not', (err, res) => {
-        expect(res).to.eql({ data: "data" });
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json' }, body: { data: "data" }});
         done();
       });
     });
@@ -472,7 +491,7 @@ describe('webreq', () => {
       this.request.callsArgWith(1, response).returns(request);
 
       return webreq.delete('https://someurl.not/id/1', { method: 'DELETE' }).then(res => {
-        expect(res).to.be.null;
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json' }, body: null });
       });
     });
 
@@ -490,7 +509,7 @@ describe('webreq', () => {
       this.request.callsArgWith(1, response).returns(request);
 
       webreq.delete('https://someurl.not/id/1', { method: 'DELETE' }, (err, res) => {
-        expect(res).to.be.null;
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json'}, body: null })
         done();
       });
     });
@@ -510,7 +529,7 @@ describe('webreq', () => {
       this.request.callsArgWith(1, response).returns(request);
 
       return webreq.delete('https://someurl.not/id/1').then(res => {
-        expect(res).to.be.null;
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json' }, body: null });
       });
     });
 
@@ -528,7 +547,7 @@ describe('webreq', () => {
       this.request.callsArgWith(1, response).returns(request);
 
       webreq.delete('https://someurl.not/id/1', (err, res) => {
-        expect(res).to.be.null;
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json' }, body: null });
         done();
       });
     });
@@ -574,7 +593,7 @@ describe('webreq', () => {
       done();
     });
 
-    it('should handle a PATCH request and parse the results (promise), enforce method', (done) => {
+    it('should handle a PATCH request and parse the results (promise), enforce method', () => {
       let mockRes = { data: "data" };
 
       let response = new PassThrough();
@@ -588,9 +607,8 @@ describe('webreq', () => {
 
       this.request.callsArgWith(1, response).returns(request);
 
-      webreq.patch('https://someurl.not/id/1').then(res => {
-        expect(res).to.eql({ data: "data" });
-        done();
+      return webreq.patch('https://someurl.not/id/1').then(res => {
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json' }, body: { data: "data" }});
       });
     });
 
@@ -609,21 +627,21 @@ describe('webreq', () => {
       this.request.callsArgWith(1, response).returns(request);
 
       webreq.patch('https://someurl.not', (err, res) => {
-        expect(res).to.eql({ data: "data" });
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json' }, body: { data: "data" }});
         done();
       });
     });
 
   });
 
-  describe('configureGlobalAgent()', () => {
+  describe('globalAgent()', () => {
     it('should configure the global agent settings of webreq (http/https)', () => {
       let httpMs = http.globalAgent.maxSockets;
       let httpMfs = http.globalAgent.maxFreeSockets;
       let httpsMs = https.globalAgent.maxSockets;
       let httpsMfs = https.globalAgent.maxFreeSockets;
 
-      webreq.configureGlobalAgent({ maxSockets: 200, maxFreeSockets: 210 });
+      webreq.globalAgent({ maxSockets: 200, maxFreeSockets: 210 });
       expect(http.globalAgent.maxSockets).to.equal(200);
       expect(http.globalAgent.maxFreeSockets).to.equal(210);
       expect(https.globalAgent.maxSockets).to.equal(200);
@@ -636,7 +654,7 @@ describe('webreq', () => {
     });
 
     it('should configure the global agent settings of webreq (http/https), no settings, leave default settings', () => {
-      webreq.configureGlobalAgent();
+      webreq.globalAgent();
       expect(http.globalAgent.maxSockets).to.equal(Infinity);
       expect(http.globalAgent.maxFreeSockets).to.equal(256);
       expect(https.globalAgent.maxSockets).to.equal(Infinity);
@@ -696,7 +714,7 @@ describe('webreq', () => {
       this.request.callsArgWith(1, response).returns(request);
 
       return webreq.request('http://someurl.not').then(res => {
-        expect(res).to.eql({ data: "data" });
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/json' }, body: { data: "data" }});
       });
     });
   });
@@ -730,11 +748,11 @@ describe('webreq', () => {
       }
 
       return webreq.request('https://someurl.not', { path: outputPath }).then(res => {
-        expect(res).to.be.null;
+        expect(res).to.eql({ statusCode: 200, headers: { 'content-type': 'application/zip', 'content-disposition': 'attachment; filename=file1.zip' }, body: null })
       });
     });
 
-    it('should handle a GET request with file upload (promise), full response', () => {
+    it('should handle a GET request with file upload (promise)', () => {
       let file = fs.readFileSync(path.join(__dirname, 'mockdata', 'file1.zip'));
 
       let response = new PassThrough();
@@ -754,7 +772,7 @@ describe('webreq', () => {
         fs.mkdirSync(outputPath);
       }
 
-      return webreq.request('https://someurl.not', { path: outputPath, bodyOnly: false }).then(res => {
+      return webreq.request('https://someurl.not', { path: outputPath }).then(res => {
         expect(res.statusCode).to.equal(200);
         expect(res.body).to.be.null;
       });
@@ -781,7 +799,7 @@ describe('webreq', () => {
         fs.mkdirSync(outputPath);
       }
 
-      return webreq.request('https://someurl.not', { path: outputPath, filename: filename, bodyOnly: false }).then(res => {
+      return webreq.request('https://someurl.not', { path: outputPath, filename: filename }).then(res => {
         expect(res.statusCode).to.equal(200);
         expect(res.body).to.be.null;
       });
@@ -807,7 +825,7 @@ describe('webreq', () => {
         fs.mkdirSync(outputPath);
       }
 
-      return webreq.request('https://someurl.not/file4.zip', { path: outputPath, bodyOnly: false }).then(res => {
+      return webreq.request('https://someurl.not/file4.zip', { path: outputPath }).then(res => {
         expect(res.statusCode).to.equal(200);
         expect(res.body).to.be.null;
       });


### PR DESCRIPTION
* Added support for providing certificate options with HTTPS requests. See further documentation: [https](https://nodejs.org/api/https.html#https_https_request_options_callback) and [tls](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback).
* Added support for using a proxy in requests. `options.proxy` set to the full URL of the proxy.
* `bodyOnly` options has been removed. This means by all responses will be of type `Response` (`statusCode`, `headers` and `body`).
* Changed function name from `configureGlobalAgent()` to `globalAgent()`.
* Can handle file uploads. Pass a read `stream` to `options.body`, or set a file path in `options.path`.
* Added **TypeScript** declaration.